### PR TITLE
Minor updates:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # - xml2rfc (https://xml2rfc.tools.ietf.org/)
 
 DRAFT=draft-ietf-dprive-xfr-over-tls
-VERSION=00
+VERSION=01
 
 XML=$(DRAFT).xml
 HTML=$(DRAFT)-$(VERSION).html

--- a/draft-ietf-dprive-xfr-over-tls-01.html
+++ b/draft-ietf-dprive-xfr-over-tls-01.html
@@ -1,0 +1,1029 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head profile="http://www.w3.org/2006/03/hcard http://dublincore.org/documents/2008/08/04/dc-html/">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii" />
+
+  <title>DNS Zone Transfer-over-TLS</title>
+
+  <style type="text/css" title="Xml2Rfc (sans serif)">
+  /*<![CDATA[*/
+	  a {
+	  text-decoration: none;
+	  }
+      /* info code from SantaKlauss at http://www.madaboutstyle.com/tooltip2.html */
+      a.info {
+          /* This is the key. */
+          position: relative;
+          z-index: 24;
+          text-decoration: none;
+      }
+      a.info:hover {
+          z-index: 25;
+          color: #FFF; background-color: #900;
+      }
+      a.info span { display: none; }
+      a.info:hover span.info {
+          /* The span will display just on :hover state. */
+          display: block;
+          position: absolute;
+          font-size: smaller;
+          top: 2em; left: -5em; width: 15em;
+          padding: 2px; border: 1px solid #333;
+          color: #900; background-color: #EEE;
+          text-align: left;
+      }
+	  a.smpl {
+	  color: black;
+	  }
+	  a:hover {
+	  text-decoration: underline;
+	  }
+	  a:active {
+	  text-decoration: underline;
+	  }
+	  address {
+	  margin-top: 1em;
+	  margin-left: 2em;
+	  font-style: normal;
+	  }
+	  body {
+	  color: black;
+	  font-family: verdana, helvetica, arial, sans-serif;
+	  font-size: 10pt;
+	  max-width: 55em;
+	  
+	  }
+	  cite {
+	  font-style: normal;
+	  }
+	  dd {
+	  margin-right: 2em;
+	  }
+	  dl {
+	  margin-left: 2em;
+	  }
+	
+	  ul.empty {
+	  list-style-type: none;
+	  }
+	  ul.empty li {
+	  margin-top: .5em;
+	  }
+	  dl p {
+	  margin-left: 0em;
+	  }
+	  dt {
+	  margin-top: .5em;
+	  }
+	  h1 {
+	  font-size: 14pt;
+	  line-height: 21pt;
+	  page-break-after: avoid;
+	  }
+	  h1.np {
+	  page-break-before: always;
+	  }
+	  h1 a {
+	  color: #333333;
+	  }
+	  h2 {
+	  font-size: 12pt;
+	  line-height: 15pt;
+	  page-break-after: avoid;
+	  }
+	  h3, h4, h5, h6 {
+	  font-size: 10pt;
+	  page-break-after: avoid;
+	  }
+	  h2 a, h3 a, h4 a, h5 a, h6 a {
+	  color: black;
+	  }
+	  img {
+	  margin-left: 3em;
+	  }
+	  li {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  ol p {
+	  margin-left: 0em;
+	  }
+	  p {
+	  margin-left: 2em;
+	  margin-right: 2em;
+	  }
+	  pre {
+	  margin-left: 3em;
+	  background-color: lightyellow;
+	  padding: .25em;
+	  }
+	  pre.text2 {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f0f0f0;
+	  width: 69em;
+	  }
+	  pre.inline {
+	  background-color: white;
+	  padding: 0em;
+	  }
+	  pre.text {
+	  border-style: dotted;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  width: 69em;
+	  }
+	  pre.drawing {
+	  border-style: solid;
+	  border-width: 1px;
+	  background-color: #f8f8f8;
+	  padding: 2em;
+	  }
+	  table {
+	  margin-left: 2em;
+	  }
+	  table.tt {
+	  vertical-align: top;
+	  }
+	  table.full {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.headers {
+	  border-style: outset;
+	  border-width: 1px;
+	  }
+	  table.tt td {
+	  vertical-align: top;
+	  }
+	  table.full td {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.tt th {
+	  vertical-align: top;
+	  }
+	  table.full th {
+	  border-style: inset;
+	  border-width: 1px;
+	  }
+	  table.headers th {
+	  border-style: none none inset none;
+	  border-width: 1px;
+	  }
+	  table.left {
+	  margin-right: auto;
+	  }
+	  table.right {
+	  margin-left: auto;
+	  }
+	  table.center {
+	  margin-left: auto;
+	  margin-right: auto;
+	  }
+	  caption {
+	  caption-side: bottom;
+	  font-weight: bold;
+	  font-size: 9pt;
+	  margin-top: .5em;
+	  }
+	
+	  table.header {
+	  border-spacing: 1px;
+	  width: 95%;
+	  font-size: 10pt;
+	  color: white;
+	  }
+	  td.top {
+	  vertical-align: top;
+	  }
+	  td.topnowrap {
+	  vertical-align: top;
+	  white-space: nowrap; 
+	  }
+	  table.header td {
+	  background-color: gray;
+	  width: 50%;
+	  }
+	  table.header a {
+	  color: white;
+	  }
+	  td.reference {
+	  vertical-align: top;
+	  white-space: nowrap;
+	  padding-right: 1em;
+	  }
+	  thead {
+	  display:table-header-group;
+	  }
+	  ul.toc, ul.toc ul {
+	  list-style: none;
+	  margin-left: 1.5em;
+	  margin-right: 0em;
+	  padding-left: 0em;
+	  }
+	  ul.toc li {
+	  line-height: 150%;
+	  font-weight: bold;
+	  font-size: 10pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  ul.toc li li {
+	  line-height: normal;
+	  font-weight: normal;
+	  font-size: 9pt;
+	  margin-left: 0em;
+	  margin-right: 0em;
+	  }
+	  li.excluded {
+	  font-size: 0pt;
+	  }
+	  ul p {
+	  margin-left: 0em;
+	  }
+	
+	  .comment {
+	  background-color: yellow;
+	  }
+	  .center {
+	  text-align: center;
+	  }
+	  .error {
+	  color: red;
+	  font-style: italic;
+	  font-weight: bold;
+	  }
+	  .figure {
+	  font-weight: bold;
+	  text-align: center;
+	  font-size: 9pt;
+	  }
+	  .filename {
+	  color: #333333;
+	  font-weight: bold;
+	  font-size: 12pt;
+	  line-height: 21pt;
+	  text-align: center;
+	  }
+	  .fn {
+	  font-weight: bold;
+	  }
+	  .hidden {
+	  display: none;
+	  }
+	  .left {
+	  text-align: left;
+	  }
+	  .right {
+	  text-align: right;
+	  }
+	  .title {
+	  color: #990000;
+	  font-size: 18pt;
+	  line-height: 18pt;
+	  font-weight: bold;
+	  text-align: center;
+	  margin-top: 36pt;
+	  }
+	  .vcardline {
+	  display: block;
+	  }
+	  .warning {
+	  font-size: 14pt;
+	  background-color: yellow;
+	  }
+	
+	
+	  @media print {
+	  .noprint {
+		display: none;
+	  }
+	
+	  a {
+		color: black;
+		text-decoration: none;
+	  }
+	
+	  table.header {
+		width: 90%;
+	  }
+	
+	  td.header {
+		width: 50%;
+		color: black;
+		background-color: white;
+		vertical-align: top;
+		font-size: 12pt;
+	  }
+	
+	  ul.toc a::after {
+		content: leader('.') target-counter(attr(href), page);
+	  }
+	
+	  ul.ind li li a {
+		content: target-counter(attr(href), page);
+	  }
+	
+	  .print2col {
+		column-count: 2;
+		-moz-column-count: 2;
+		column-fill: auto;
+	  }
+	  }
+	
+	  @page {
+	  @top-left {
+		   content: "Internet-Draft"; 
+	  } 
+	  @top-right {
+		   content: "December 2010"; 
+	  } 
+	  @top-center {
+		   content: "Abbreviated Title";
+	  } 
+	  @bottom-left {
+		   content: "Doe"; 
+	  } 
+	  @bottom-center {
+		   content: "Expires June 2011"; 
+	  } 
+	  @bottom-right {
+		   content: "[Page " counter(page) "]"; 
+	  } 
+	  }
+	
+	  @page:first { 
+		@top-left {
+		  content: normal;
+		}
+		@top-right {
+		  content: normal;
+		}
+		@top-center {
+		  content: normal;
+		}
+	  }
+  /*]]>*/
+  </style>
+
+  <link href="#rfc.toc" rel="Contents"/>
+<link href="#rfc.section.1" rel="Chapter" title="1 Introduction"/>
+<link href="#rfc.section.2" rel="Chapter" title="2 Terminology"/>
+<link href="#rfc.section.3" rel="Chapter" title="3 Use Cases for XFR-over-TLS"/>
+<link href="#rfc.section.4" rel="Chapter" title="4 Connection and Data Flows in Existing XFR Mechanisms"/>
+<link href="#rfc.section.4.1" rel="Chapter" title="4.1 AXFR Mechanism"/>
+<link href="#rfc.section.4.2" rel="Chapter" title="4.2 IXFR Mechanism"/>
+<link href="#rfc.section.4.3" rel="Chapter" title="4.3 Data Leakage of NOTIFY and SOA Message Exchanges"/>
+<link href="#rfc.section.4.3.1" rel="Chapter" title="4.3.1 NOTIFY"/>
+<link href="#rfc.section.4.3.2" rel="Chapter" title="4.3.2 SOA"/>
+<link href="#rfc.section.5" rel="Chapter" title="5 Connection and Data Flows in XoT"/>
+<link href="#rfc.section.5.1" rel="Chapter" title="5.1 Performance Considerations"/>
+<link href="#rfc.section.5.2" rel="Chapter" title="5.2 AXoT mechanism"/>
+<link href="#rfc.section.5.3" rel="Chapter" title="5.3 IXoT mechanism"/>
+<link href="#rfc.section.5.3.1" rel="Chapter" title="5.3.1 Fallback to AXFR"/>
+<link href="#rfc.section.6" rel="Chapter" title="6 Zone Transfer with DoT - Authentication"/>
+<link href="#rfc.section.6.1" rel="Chapter" title="6.1 TSIG"/>
+<link href="#rfc.section.6.2" rel="Chapter" title="6.2 SIG(0)"/>
+<link href="#rfc.section.6.3" rel="Chapter" title="6.3 TLS"/>
+<link href="#rfc.section.6.3.1" rel="Chapter" title="6.3.1 Opportunistic"/>
+<link href="#rfc.section.6.3.2" rel="Chapter" title="6.3.2 Strict"/>
+<link href="#rfc.section.6.3.3" rel="Chapter" title="6.3.3 Mutual"/>
+<link href="#rfc.section.6.4" rel="Chapter" title="6.4 IP Based ACL on the Primary"/>
+<link href="#rfc.section.6.5" rel="Chapter" title="6.5 ZONEMD"/>
+<link href="#rfc.section.6.6" rel="Chapter" title="6.6 Comparison of Authentication Methods"/>
+<link href="#rfc.section.7" rel="Chapter" title="7 Policies for Both AXFR and IXFR"/>
+<link href="#rfc.section.8" rel="Chapter" title="8 Multi-primary Configurations"/>
+<link href="#rfc.section.9" rel="Chapter" title="9 Implementation Considerations"/>
+<link href="#rfc.section.10" rel="Chapter" title="10 Implementation Status"/>
+<link href="#rfc.section.11" rel="Chapter" title="11 IANA Considerations"/>
+<link href="#rfc.section.12" rel="Chapter" title="12 Security Considerations"/>
+<link href="#rfc.section.13" rel="Chapter" title="13 Acknowledgements"/>
+<link href="#rfc.section.14" rel="Chapter" title="14 Changelog"/>
+<link href="#rfc.references" rel="Chapter" title="15 References"/>
+<link href="#rfc.references.1" rel="Chapter" title="15.1 Normative References"/>
+<link href="#rfc.references.2" rel="Chapter" title="15.2 Informative References"/>
+<link href="#rfc.authors" rel="Chapter"/>
+
+
+  <meta name="generator" content="xml2rfc version 2.5.1 - http://tools.ietf.org/tools/xml2rfc" />
+  <link rel="schema.dct" href="http://purl.org/dc/terms/" />
+
+  <meta name="dct.creator" content="Zhang, H., Aras, P., Toorop, W., Dickinson, S., and A. Mankin" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-dprive-xfr-over-tls-01" />
+  <meta name="dct.issued" scheme="ISO8601" content="2020-5-19" />
+  <meta name="dct.abstract" content="DNS zone transfers are transmitted in clear text, which gives attackers the opportunity to collect the content of a zone by eavesdropping on network connections. The DNS Transaction Signature (TSIG) mechanism is specified to restrict direct zone transfer to authorized clients only, but it does not add confidentiality. This document specifies use of DNS-over-TLS to prevent zone contents collection via passive monitoring of zone transfers.  " />
+  <meta name="description" content="DNS zone transfers are transmitted in clear text, which gives attackers the opportunity to collect the content of a zone by eavesdropping on network connections. The DNS Transaction Signature (TSIG) mechanism is specified to restrict direct zone transfer to authorized clients only, but it does not add confidentiality. This document specifies use of DNS-over-TLS to prevent zone contents collection via passive monitoring of zone transfers.  " />
+
+</head>
+
+<body>
+
+  <table class="header">
+    <tbody>
+    
+    	<tr>
+  <td class="left">dprive</td>
+  <td class="right">H. Zhang</td>
+</tr>
+<tr>
+  <td class="left">Internet-Draft</td>
+  <td class="right">P. Aras</td>
+</tr>
+<tr>
+  <td class="left">Updates: 1995 (if approved)</td>
+  <td class="right">Salesforce</td>
+</tr>
+<tr>
+  <td class="left">Intended status: Standards Track</td>
+  <td class="right">W. Toorop</td>
+</tr>
+<tr>
+  <td class="left">Expires: November 20, 2020</td>
+  <td class="right">NLnet Labs</td>
+</tr>
+<tr>
+  <td class="left"></td>
+  <td class="right">S. Dickinson</td>
+</tr>
+<tr>
+  <td class="left"></td>
+  <td class="right">Sinodun IT</td>
+</tr>
+<tr>
+  <td class="left"></td>
+  <td class="right">A. Mankin</td>
+</tr>
+<tr>
+  <td class="left"></td>
+  <td class="right">Salesforce</td>
+</tr>
+<tr>
+  <td class="left"></td>
+  <td class="right">May 19, 2020</td>
+</tr>
+
+    	
+    </tbody>
+  </table>
+
+  <p class="title">DNS Zone Transfer-over-TLS<br />
+  <span class="filename">draft-ietf-dprive-xfr-over-tls-01</span></p>
+  
+  <h1 id="rfc.abstract">
+  <a href="#rfc.abstract">Abstract</a>
+</h1>
+<p>DNS zone transfers are transmitted in clear text, which gives attackers the opportunity to collect the content of a zone by eavesdropping on network connections. The DNS Transaction Signature (TSIG) mechanism is specified to restrict direct zone transfer to authorized clients only, but it does not add confidentiality. This document specifies use of DNS-over-TLS to prevent zone contents collection via passive monitoring of zone transfers.  </p>
+<h1 id="rfc.status">
+  <a href="#rfc.status">Status of This Memo</a>
+</h1>
+<p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
+<p>This Internet-Draft will expire on November 20, 2020.</p>
+<h1 id="rfc.copyrightnotice">
+  <a href="#rfc.copyrightnotice">Copyright Notice</a>
+</h1>
+<p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+
+  
+  <hr class="noprint" />
+  <h1 class="np" id="rfc.toc"><a href="#rfc.toc">Table of Contents</a></h1>
+  <ul class="toc">
+
+  	<li>1.   <a href="#rfc.section.1">Introduction</a></li>
+<li>2.   <a href="#rfc.section.2">Terminology</a></li>
+<li>3.   <a href="#rfc.section.3">Use Cases for XFR-over-TLS</a></li>
+<li>4.   <a href="#rfc.section.4">Connection and Data Flows in Existing XFR Mechanisms</a></li>
+<ul><li>4.1.   <a href="#rfc.section.4.1">AXFR Mechanism</a></li>
+<li>4.2.   <a href="#rfc.section.4.2">IXFR Mechanism</a></li>
+<li>4.3.   <a href="#rfc.section.4.3">Data Leakage of NOTIFY and SOA Message Exchanges</a></li>
+<ul><li>4.3.1.   <a href="#rfc.section.4.3.1">NOTIFY</a></li>
+<li>4.3.2.   <a href="#rfc.section.4.3.2">SOA</a></li>
+</ul></ul><li>5.   <a href="#rfc.section.5">Connection and Data Flows in XoT</a></li>
+<ul><li>5.1.   <a href="#rfc.section.5.1">Performance Considerations</a></li>
+<li>5.2.   <a href="#rfc.section.5.2">AXoT mechanism</a></li>
+<li>5.3.   <a href="#rfc.section.5.3">IXoT mechanism</a></li>
+<ul><li>5.3.1.   <a href="#rfc.section.5.3.1">Fallback to AXFR</a></li>
+</ul></ul><li>6.   <a href="#rfc.section.6">Zone Transfer with DoT - Authentication</a></li>
+<ul><li>6.1.   <a href="#rfc.section.6.1">TSIG</a></li>
+<li>6.2.   <a href="#rfc.section.6.2">SIG(0)</a></li>
+<li>6.3.   <a href="#rfc.section.6.3">TLS</a></li>
+<ul><li>6.3.1.   <a href="#rfc.section.6.3.1">Opportunistic</a></li>
+<li>6.3.2.   <a href="#rfc.section.6.3.2">Strict</a></li>
+<li>6.3.3.   <a href="#rfc.section.6.3.3">Mutual</a></li>
+</ul><li>6.4.   <a href="#rfc.section.6.4">IP Based ACL on the Primary</a></li>
+<li>6.5.   <a href="#rfc.section.6.5">ZONEMD</a></li>
+<li>6.6.   <a href="#rfc.section.6.6">Comparison of Authentication Methods</a></li>
+</ul><li>7.   <a href="#rfc.section.7">Policies for Both AXFR and IXFR</a></li>
+<li>8.   <a href="#rfc.section.8">Multi-primary Configurations</a></li>
+<li>9.   <a href="#rfc.section.9">Implementation Considerations</a></li>
+<li>10.   <a href="#rfc.section.10">Implementation Status</a></li>
+<li>11.   <a href="#rfc.section.11">IANA Considerations</a></li>
+<li>12.   <a href="#rfc.section.12">Security Considerations</a></li>
+<li>13.   <a href="#rfc.section.13">Acknowledgements</a></li>
+<li>14.   <a href="#rfc.section.14">Changelog</a></li>
+<li>15.   <a href="#rfc.references">References</a></li>
+<ul><li>15.1.   <a href="#rfc.references.1">Normative References</a></li>
+<li>15.2.   <a href="#rfc.references.2">Informative References</a></li>
+</ul><li><a href="#rfc.authors">Authors' Addresses</a></li>
+
+
+  </ul>
+
+  <h1 id="rfc.section.1"><a href="#rfc.section.1">1.</a> <a href="#introduction" id="introduction">Introduction</a></h1>
+<p id="rfc.section.1.p.1">DNS has a number of privacy vulnerabilities, as discussed in detail in <a href="#I-D.ietf-dprive-rfc7626-bis">[I-D.ietf-dprive-rfc7626-bis]</a>. Stub client to recursive resolver query privacy has received the most attention to date. There are now standards track documents for three encryption capabilities for stub to recursive queries and more work going on to guide deployment of specifically DNS-over-TLS (DoT) <a href="#RFC7858">[RFC7858]</a> and DNS-over-HTTPS (DoH) <a href="#RFC8484">[RFC8484]</a>.  </p>
+<p><a href="#I-D.ietf-dprive-rfc7626-bis">[I-D.ietf-dprive-rfc7626-bis]</a> established that stub client DNS query transactions are not public and needed protection, but on zone transfer <a href="#RFC1995">[RFC1995]</a> <a href="#RFC5936">[RFC5936]</a> it says only: </p>
+<p id="rfc.section.1.p.3">"Privacy risks for the holder of a zone (the risk that someone gets the data) are discussed in [RFC5936] and [RFC5155]." </p>
+<p id="rfc.section.1.p.4">In what way is exposing the full contents of a zone a privacy risk? The contents of the zone could include information such as names of persons used in names of hosts. Best practice is not to use personal information for domain names, but many such domain names exist. There may also be regulatory, policy or other reasons why the zone contents in full must be treated as private.  </p>
+<p id="rfc.section.1.p.5">Neither of the RFCs mentioned in <a href="#I-D.ietf-dprive-rfc7626-bis">[I-D.ietf-dprive-rfc7626-bis]</a> contemplates the risk that someone gets the data through eavesdropping on network connections, only via enumeration or unauthorized transfer as described in the following paragraphs.  </p>
+<p><a href="#RFC5155">[RFC5155]</a> specifies NSEC3 to prevent zone enumeration, which is when queries for the authenticated denial of existences records of DNSSEC allow a client to walk through the entire zone. Note that the need for this protection also motivates NSEC5 <a href="#I-D.vcelak-nsec5">[I-D.vcelak-nsec5]</a>; zone walking is now possible with NSEC3 due to crypto-breaking advances, and NSEC5 is a response to this problem.  </p>
+<p><a href="#RFC5155">[RFC5155]</a> does not address data obtained outside zone enumeration (nor does <a href="#I-D.vcelak-nsec5">[I-D.vcelak-nsec5]</a>). Preventing eavesdropping of zone transfers (this draft) is orthogonal to preventing zone enumeration, though they aim to protect the same information.  </p>
+<p><a href="#RFC5936">[RFC5936]</a> specifies using TSIG <a href="#RFC2845">[RFC2845]</a> for authorization of the clients of a zone transfer and for data integrity, but does not express any need for confidentiality, and TSIG does not offer encryption. Some operators use SSH tunneling or IPSec to encrypt the transfer data.  </p>
+<p id="rfc.section.1.p.9">Because the AXFR zone transfer is typically carried out-over-TCP from authoritative DNS protocol implementations, encrypting AXFR using DNS-over-TLS <a href="#RFC7858">[RFC7858]</a> seems like a simple step forward. This document specifies how to use DoT to prevent zone collection from zone transfers, including discussion of approaches for IXFR, which uses UDP or TCP.  </p>
+<h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> <a href="#terminology" id="terminology">Terminology</a></h1>
+<p id="rfc.section.2.p.1">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <a href="#RFC2119">[RFC2119]</a> and <a href="#RFC8174">[RFC8174]</a> when, and only when, they appear in all capitals, as shown here.  </p>
+<p id="rfc.section.2.p.2">Privacy terminology is as described in Section 3 of <a href="#RFC6973">[RFC6973]</a>.  </p>
+<p id="rfc.section.2.p.3">Note that in this document we choose to use the terms 'primary' and 'secondary' for two servers engaged in zone transfers.  </p>
+<p id="rfc.section.2.p.4">DNS terminology is as described in <a href="#RFC8499">[RFC8499]</a>.  </p>
+<p id="rfc.section.2.p.5">DoT: DNS-over-TLS as specified in <a href="#RFC7858">[RFC7858]</a> </p>
+<p id="rfc.section.2.p.6">XoT: Generic XFR-over-TLS mechanisms as specified in this document </p>
+<p id="rfc.section.2.p.7">AXoT: AXFR-over-TLS </p>
+<p id="rfc.section.2.p.8">IXoT: IXFR over-TLS </p>
+<h1 id="rfc.section.3"><a href="#rfc.section.3">3.</a> <a href="#use-cases-for-xfrovertls" id="use-cases-for-xfrovertls">Use Cases for XFR-over-TLS</a></h1>
+<p/>
+
+<ul>
+  <li>Confidentiality. Clearly using an encrypted transport for zone transfers will defeat zone content leakage that can occur via passive surveillance.</li>
+  <li>Authentication. Use of single or mutual TLS authentication (in combination with ACLs) can complement and potentially be an alternative to TSIG.</li>
+  <li>Performance. Existing AXFR and IXFR mechanisms have the burden of backwards compatibility with older implementations based on the original specifications in <a href="#RFC1034">[RFC1034]</a> and <a href="#RFC1035">[RFC1035]</a>. For example, some older AXFR servers don&#8217;t support using a TCP connection for multiple AXFR sessions or XFRs of different zones because they have not been updated to follow the guidance in <a href="#RFC5936">[RFC5936]</a>.  Any implementation of XFR-over-TLS would obviously be required to implement optimized and interoperable transfers as described in <a href="#RFC5936">[RFC5936]</a> e.g. transfer of multiple zones over one connection.</li>
+  <li>Performance. Current usage of TCP for IXFR is sub-optimal in some cases i.e.  connections are frequently closed after a single IXFR.</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.4"><a href="#rfc.section.4">4.</a> <a href="#connection-and-data-flows-in-existing-xfr-mechanisms" id="connection-and-data-flows-in-existing-xfr-mechanisms">Connection and Data Flows in Existing XFR Mechanisms</a></h1>
+<p id="rfc.section.4.p.1">The original specification for zone transfers in <a href="#RFC1034">[RFC1034]</a> and <a href="#RFC1035">[RFC1035]</a> was based on a polling mechanism: a secondary performed a periodic SOA query (based on the refresh timer) to determine if an AXFR was required.  </p>
+<p><a href="#RFC1995">[RFC1995]</a> and <a href="#RFC1996">[RFC1996]</a> introduced the concepts of IXFR and NOTIFY respectively, to provide for prompt propagation of zone updates. This has largely replaced AXFR where possible, particularly for dynamically updated zones.  </p>
+<p><a href="#RFC5936">[RFC5936]</a> subsequently redefined the specification of AXFR to improve performance and interoperability.  </p>
+<p id="rfc.section.4.p.4">In this document we use the phrase "XFR mechanism" to describe the entire set of message exchanges between a secondary and a primary that concludes in a successful AXFR or IXFR request/response. This set may or may not include </p>
+<p/>
+
+<ul>
+  <li>NOTIFY messages</li>
+  <li>SOA queries</li>
+  <li>Fallback from IXFR to AXFR</li>
+  <li>Fallback from IXFR-over-UDP to IXFR-over-TCP</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.4.p.6">The term is used to encompasses the range of permutations that are possible and is useful to distinguish the 'XFR mechanism' from a single XFR request/response exchange.  </p>
+<h1 id="rfc.section.4.1"><a href="#rfc.section.4.1">4.1.</a> <a href="#axfr-mechanism" id="axfr-mechanism">AXFR Mechanism</a></h1>
+<p id="rfc.section.4.1.p.1">The figure below provides an outline of an AXFR mechanism including NOTIFYs.  </p>
+<p><a href="https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/blob/02_updates/02-draft-svg/AXFR_mechanism.svg">Figure 1. AXFR Mechanism</a> </p>
+<p/>
+
+<ol>
+  <li>An AXFR is often (but not always) preceded by a NOTIFY (over UDP) from the primary to the secondary. A secondary may also initiate an AXFR based on a refresh timer or scheduled/triggered zone maintenance.</li>
+  <li>The secondary will normally (but not always) make a SOA query to the primary to obtain the serial number of the zone held by the primary.</li>
+  <li>If the primary serial is higher than the secondaries serial (using Serial Number Arithmetic <a href="#RFC1982">[RFC1982]</a>), the secondary makes an AXFR request (over TCP) to the primary after which the AXFR data flows in one or more AXFR responses on the TCP connection.</li>
+</ol>
+
+<p> </p>
+<p><a href="#RFC5936">[RFC5936]</a> specifies that AXFR must use TCP as the transport protocol but details that there is no restriction in the protocol that a single TCP session must be used only for a single AXFR exchange, or even solely for XFRs. For example, it outlines that the SOA query can also happen on this connection.  However, this can cause interoperability problems with older implementations that support only the trivial case of one AXFR per connection.  </p>
+<p id="rfc.section.4.1.p.5">Further details of the limitations in existing AXFR implementations are outlined in <a href="#RFC5936">[RFC5936]</a>.  </p>
+<p id="rfc.section.4.1.p.6">It is noted that unless the NOTIFY is sent over a trusted communication channel and/or signed by TSIG is can be spoofed causing unnecessary zone transfer attempts.  </p>
+<p id="rfc.section.4.1.p.7">Similarly unless the SOA query is sent over a trusted communication channel and/or signed by TSIG the response can, in principle, be spoofed causing a secondary to incorrectly believe its version of the zone is update to date.  Repeated successful attacks on the SOA could result in a secondary serving stale zone data.  </p>
+<h1 id="rfc.section.4.2"><a href="#rfc.section.4.2">4.2.</a> <a href="#ixfr-mechanism" id="ixfr-mechanism">IXFR Mechanism</a></h1>
+<p id="rfc.section.4.2.p.1">The figure below provides an outline of the IXFR mechanism including NOTIFYs.  </p>
+<p><a href="https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/blob/02_updates/02-draft-svg/IXFR%20mechanism.svg">Figure 1. IXFR Mechanism</a> </p>
+<p/>
+
+<ol>
+  <li>An IXFR is normally (but not always) preceded by a NOTIFY (over UDP) from the primary to the secondary. A secondary may also initiate an IXFR based on a refresh timer or scheduled/triggered zone maintenance.</li>
+  <li>The secondary will normally (but not always) make a SOA query to the primary to obtain the serial number of the zone held by the primary.</li>
+  <li>If the primary serial is higher than the secondaries serial (using Serial Number Arithmetic <a href="#RFC1982">[RFC1982]</a>), the secondary makes an IXFR request to the primary after the primary sends an IXFR response.</li>
+</ol>
+
+<p> </p>
+<p><a href="#RFC1995">[RFC1995]</a> specifies that Incremental Transfer may use UDP if the entire IXFR response can be contained in a single DNS packet, otherwise, TCP is used. In fact is says in non-normative language: </p>
+<p id="rfc.section.4.2.p.5">"Thus, a client should first make an IXFR query using UDP." </p>
+<p id="rfc.section.4.2.p.6">So there may be a forth step above where the client falls back to IXFR-over-TCP.  There may also be a forth step where the secondary must fall back to AXFR because e.g. the primary does not support IXFR.  </p>
+<p id="rfc.section.4.2.p.7">However it is noted that at least two widely used open source authoritative nameserver implementations (<a href="https://www.isc.org/bind/">BIND</a> and <a href="https://www.nlnetlabs.nl/projects/nsd/about/">NSD</a>) do IXFR using TCP by default in their latest releases. For BIND TCP connections are sometimes used for SOA queries but in general they are not used persistently and close after an IXFR is completed.  </p>
+<p id="rfc.section.4.2.p.8">It is noted that the specification for IXFR was published well before TCP was considered a first class transport for DNS. This document therefore updates <a href="#RFC1995">[RFC1995]</a> to state that DNS implementations that support IXFR-over-TCP MUST use <a href="#RFC7766">[RFC7766]</a> to optimise the use of TCP connections and SHOULD use <a href="#RFC7858">[RFC7858]</a> to manage persistent connections.  </p>
+<h1 id="rfc.section.4.3"><a href="#rfc.section.4.3">4.3.</a> <a href="#data-leakage-of-notify-and-soa-message-exchanges" id="data-leakage-of-notify-and-soa-message-exchanges">Data Leakage of NOTIFY and SOA Message Exchanges</a></h1>
+<p id="rfc.section.4.3.p.1">This section attempts to presents a rationale for also encrypting the other messages in the XFR mechanism.  </p>
+<p id="rfc.section.4.3.p.2">Since the SOA of the published zone can be trivially discovered by simply querying the publicly available authoritative servers leakage of this RR is not discussed in the following sections.  </p>
+<h1 id="rfc.section.4.3.1"><a href="#rfc.section.4.3.1">4.3.1.</a> <a href="#notify" id="notify">NOTIFY</a></h1>
+<p id="rfc.section.4.3.1.p.1">Unencrypted NOTIFY messages identify configured secondaries on the primary.  </p>
+<p><a href="#RFC1996">[RFC1996]</a> also states: </p>
+<p id="rfc.section.4.3.1.p.3">"If ANCOUNT&gt;0, then the answer section represents an unsecure hint at the new RRset for this .  </p>
+<p id="rfc.section.4.3.1.p.4">But since the only supported QTYPE for NOTIFY is SOA, this does not pose a potential leak.  </p>
+<h1 id="rfc.section.4.3.2"><a href="#rfc.section.4.3.2">4.3.2.</a> <a href="#soa" id="soa">SOA</a></h1>
+<p id="rfc.section.4.3.2.p.1">For hidden primaries or secondaries the SOA response leaks the degree of lag of any downstream secondary.  </p>
+<h1 id="rfc.section.5"><a href="#rfc.section.5">5.</a> <a href="#connection-and-data-flows-in-xot" id="connection-and-data-flows-in-xot">Connection and Data Flows in XoT</a></h1>
+<h1 id="rfc.section.5.1"><a href="#rfc.section.5.1">5.1.</a> <a href="#performance-considerations" id="performance-considerations">Performance Considerations</a></h1>
+<p id="rfc.section.5.1.p.1">The details in <a href="#RFC7766">[RFC7766]</a>, <a href="#RFC7858">[RFC7858]</a> and <a href="#RFC8310">[RFC8310]</a> about e.g. using persistent connections and TLS Session Resumption <a href="#RFC5077">[RFC5077]</a> are fully applicable to XFR-over-TLS as well.  </p>
+<p id="rfc.section.5.1.p.2">It is RECOMMENDED that clients and servers that support XoT also implement EDNS0 Keepalive [RFC7828].  </p>
+<p id="rfc.section.5.1.p.3">It is useful to note that in these mechanisms is it the secondary that initiates the TLS connection to the primary for a XFR request, so that in terms of connectivity the secondary is the TLS client and the primary the TLS server.  </p>
+<h1 id="rfc.section.5.2"><a href="#rfc.section.5.2">5.2.</a> <a href="#axot-mechanism" id="axot-mechanism">AXoT mechanism</a></h1>
+<p id="rfc.section.5.2.p.1">The figure below provides an outline of the AXoT mechanism including NOTIFYs.  </p>
+<p><a href="https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/blob/02_updates/02-draft-svg/AXoT_mechanism_1.svg">Figure 3: AXoT mechanism</a> </p>
+<p id="rfc.section.5.2.p.3">The connection for AXFR-over-TLS SHOULD be established using port 853, as specified in <a href="#RFC7858">[RFC7858]</a>, unless there is mutual agreement between the secondary and primary to use a port other than port 853 for XFR-over-TLS.  </p>
+<p id="rfc.section.5.2.p.4">All implementations that support XoT MUST fully implement <a href="#RFC5953">[RFC5953]</a> behavior on TLS connections.  </p>
+<p id="rfc.section.5.2.p.5">Sections 4.1, 4.1.1 and 4.1.2 of <a href="#RFC5936">[RFC5936]</a> describe guidance for AXFR clients and servers with regard to re-use of sessions for multiple AXFRs, AXFRs of different zones and using TCP session for other queries including SOA.  </p>
+<p id="rfc.section.5.2.p.6">For clarity we restate here that an AXoT client MAY use an already opened TLS connection to send a AXFR request. Using an existing open connection is RECOMMENDED over opening a new connection. (Non-AXoT session traffic can also use an open connection.) </p>
+<p id="rfc.section.5.2.p.7">For clarity we additionally state here that an AXoT client MAY use an already opened TLS connection to send a SOA request. Using an existing open connection is RECOMMENDED over opening a new connection.  </p>
+<p id="rfc.section.5.2.p.8">QUESTION: Should there be a requirement that the SOA is always done on a TLS connection if the XFR is? For the case when no transfer is required this could be unnecessary overhead.  </p>
+<h1 id="rfc.section.5.3"><a href="#rfc.section.5.3">5.3.</a> <a href="#ixot-mechanism" id="ixot-mechanism">IXoT mechanism</a></h1>
+<p id="rfc.section.5.3.p.1">The figure below provides an outline of the IXoT mechanism including NOTIFYs.  </p>
+<p><a href="https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/blob/02_updates/02-draft-svg/IXoT_mechanism_1.svg">Figure 4: IXoT mechanism</a> </p>
+<p id="rfc.section.5.3.p.3">The connection for IXFR-over-TLS SHOULD be established using port 853, as specified in <a href="#RFC7858">[RFC7858]</a>, unless there is mutual agreement between the secondary and primary to use a port other than port 853 for XFR-over-TLS.  </p>
+<p><a href="#RFC1995">[RFC1995]</a> says nothing with respect to optimizing IXFRs over TCP or re-using already open TCP connections to perform IXFRs or other queries. We provide guidance here that aligns with the guidance in <a href="#RFC5936">[RFC5936]</a> for AXFR and with that for performant TCP/TLS usage in <a href="#RFC7766">[RFC7766]</a> and <a href="#RFC7858">[RFC7858]</a>.  </p>
+<p id="rfc.section.5.3.p.5">An IXoT client MAY use an already opened TLS connection to send a IXFR request.  Using an existing open connection is RECOMMENDED over opening a new connection.  (Non-IXoT session traffic can also use an open connection.) </p>
+<p id="rfc.section.5.3.p.6">An IXoT client MAY use an already open TLS connection to send an SOA query.  Using an existing open connection is RECOMMENDED over opening a new connection.  </p>
+<p id="rfc.section.5.3.p.7">An IXoT server MUST be able to handle multiple IXoT requests on a single TLS connection, as well as to handle other query/response transactions over it.  </p>
+<p id="rfc.section.5.3.p.8">An IXoT client MAY keep an existing TLS session open in the expectation it is likely to need to perform an IXFR in the near future. The client may use the frequency of recent IXFRs to calculate an average update rate and then use EDNS0 Keepalive to request an appropriate timeout from the server (if the server supports EDNS0 Keepalive). If the server does not support EDNS0 Keepalive the client MAY keep the connection open for a few seconds (<a href="#RFC7766">[RFC7766]</a> recommends that servers use timeouts of at least a few seconds).  </p>
+<p id="rfc.section.5.3.p.9">An IXoT client MAY pipeline IXFR requests for different zones on a single TLS connection. AN IXoT server MAY respond to those requests out of order.  </p>
+<p id="rfc.section.5.3.p.10">QUESTION: Since this is a new specification should there be a requirement that IXoT servers are RECOMMENDED to condense responses as described in Section 6 of [RFC1995]. [RFC1995] document says this is optional and MAY be done but it can significantly reduce the size of responses and may have implications for padding? </p>
+<h1 id="rfc.section.5.3.1"><a href="#rfc.section.5.3.1">5.3.1.</a> <a href="#fallback-to-axfr" id="fallback-to-axfr">Fallback to AXFR</a></h1>
+<p id="rfc.section.5.3.1.p.1">Fallback to AXFR can happen, for example, if the server is not able to provide an IXFR for the requested SOA. Implementations differ in how long they store zone deltas and how many may be stored at any one time.  </p>
+<p id="rfc.section.5.3.1.p.2">After a failed IXFR a IXoT client SHOULD request the AXFR on the already open TLS connection.  </p>
+<h1 id="rfc.section.6"><a href="#rfc.section.6">6.</a> <a href="#zone-transfer-with-dot--authentication" id="zone-transfer-with-dot--authentication">Zone Transfer with DoT - Authentication</a></h1>
+<h1 id="rfc.section.6.1"><a href="#rfc.section.6.1">6.1.</a> <a href="#tsig" id="tsig">TSIG</a></h1>
+<p id="rfc.section.6.1.p.1">TSIG <a href="#RFC2845">[RFC2845]</a> provides a mechanism for two parties to exchange secret keys which can then be used to create a message digest to protect individual DNS messages. This allows each party to authenticate that a request or response (and the data in it) came from the other party, even if it was transmitted-over-an unsecured channel or via a proxy. It provides party-to-party data authentication, but not hop-to-hop channel authentication or confidentiality.  </p>
+<h1 id="rfc.section.6.2"><a href="#rfc.section.6.2">6.2.</a> <a href="#sig0" id="sig0">SIG(0)</a></h1>
+<p id="rfc.section.6.2.p.1">TBD </p>
+<h1 id="rfc.section.6.3"><a href="#rfc.section.6.3">6.3.</a> <a href="#tls" id="tls">TLS</a></h1>
+<h1 id="rfc.section.6.3.1"><a href="#rfc.section.6.3.1">6.3.1.</a> <a href="#opportunistic" id="opportunistic">Opportunistic</a></h1>
+<p id="rfc.section.6.3.1.p.1">Opportunistic TLS <a href="#RFC8310">[RFC8310]</a> provides a defence against passive surveillance, providing on-the-wire confidentiality.  </p>
+<h1 id="rfc.section.6.3.2"><a href="#rfc.section.6.3.2">6.3.2.</a> <a href="#strict" id="strict">Strict</a></h1>
+<p id="rfc.section.6.3.2.p.1">Strict TLS <a href="#RFC8310">[RFC8310]</a> requires that a client is configured with an authentication domain name (and/or SPKI pinset) that should be used to authenticate the TLS handshake with the server. This additionally provides a defense for the client against active surveillance, providing client-to-server authentication and end-to-end channel confidentiality.  </p>
+<h1 id="rfc.section.6.3.3"><a href="#rfc.section.6.3.3">6.3.3.</a> <a href="#mutual" id="mutual">Mutual</a></h1>
+<p id="rfc.section.6.3.3.p.1">This is an extension to Strict TLS <a href="#RFC8310">[RFC8310]</a> which requires that a client is configured with an authentication domain name (and/or SPKI pinset) and a client certificate. The client offers the certificate for authentication by the server and the client can authentic the server the same way as in Strict TLS. This provides a defense for both parties against active surveillance, providing bi-directional authentication and end-to-end channel confidentiality.  </p>
+<h1 id="rfc.section.6.4"><a href="#rfc.section.6.4">6.4.</a> <a href="#ip-based-acl-on-the-primary" id="ip-based-acl-on-the-primary">IP Based ACL on the Primary</a></h1>
+<p id="rfc.section.6.4.p.1">Most DNS server implementations offer an option to configure an IP based Access Control List (ACL), which is often used in combination with TSIG based ACLs to restrict access to zone transfers on primary servers.  </p>
+<p id="rfc.section.6.4.p.2">This is also possible with XoT but it must be noted that as with TCP the implementation of such an ACL cannot be enforced on the primary until a XFR request is received on an established connection.  </p>
+<p id="rfc.section.6.4.p.3">If control were to be any more fine-grained than this then a separate, dedicated port would need to be agreed between primary and secondary for XoT such that implementations would be able to refuse connections on that port to all clients except those configured as secondaries.  </p>
+<h1 id="rfc.section.6.5"><a href="#rfc.section.6.5">6.5.</a> <a href="#zonemd" id="zonemd">ZONEMD</a></h1>
+<p id="rfc.section.6.5.p.1">Message Digest for DNS Zones (ZONEMD) <a href="#I-D.ietf-dnsop-dns-zone-digest">[I-D.ietf-dnsop-dns-zone-digest]</a> digest is a mechanism that can be used to verify the content of a standalone zone. It is designed to be independent of the transmission channel or mechanism, allowing a general consumer of a zone to do origin authentication of the entire zone contents. Note that the current version of <a href="#I-D.ietf-dnsop-dns-zone-digest">[I-D.ietf-dnsop-dns-zone-digest]</a> states: </p>
+<p><samp>As specified at this time, ZONEMD is not designed for use in large, dynamic zones due to the time and resources required for digest calculation. The ZONEMD record described in this document includes fields reserved for future work to support large, dynamic zones.</samp> </p>
+<p id="rfc.section.6.5.p.3">It is complementary the above mechanisms and can be used in conjunction with XFR-over-TLS but is not considered further.  </p>
+<h1 id="rfc.section.6.6"><a href="#rfc.section.6.6">6.6.</a> <a href="#comparison-of-authentication-methods" id="comparison-of-authentication-methods">Comparison of Authentication Methods</a></h1>
+<p id="rfc.section.6.6.p.1">The Table below compares the properties of each of the above methods in terms of what protection they provide to the secondary and primary servers during XoT in terms of: </p>
+<p/>
+
+<ul>
+  <li>'Data Auth': Authentication that the DNS message data is signed by the party with whom credentials were shared (the signing party may or may not be party operating the far end of a TCP/TLS connection in a 'proxy' scenario). For the primary the TSIG on the XFR request confirms that the requesting party is authorized to request zone data, for the secondary it authenticates the zone data that is received.</li>
+  <li>'Channel Conf': Confidentiality of the communication channel between the client and server (i.e. the two end points of a TCP/TLS connection).</li>
+  <li>Channel Auth: Authentication of the identity of party to whom a TCP/TLS connection is made (this might not be a direct connection between the primary and secondary in a proxy scenario).</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.6.6.p.3">It is noted that zone transfer scenarios can vary from a simple single primary/secondary relationship where both servers are under the control of a single operator to a complex hierarchical structure which includes proxies and multiple operators. Each deployment scenario will require specific analysis to determine which authentication methods are best suited to the deployment model in question.  </p>
+<p><a href="https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/blob/02_updates/02-draft-svg/Properties_of_Authentication_methods_for_XoT.svg">Table 1: Properties of Authentication methods for XoT</a> </p>
+<p id="rfc.section.6.6.p.5">Based on this analysis it can be seen that: </p>
+<p/>
+
+<ul>
+  <li>A combination of Opportunistic TLS and TSIG provides both data authentication and channel confidentiality for both parties. However this does not stop a MitM attack on the channel which could be used to gather zone data.</li>
+  <li>Using just mutual TLS can be considered a standalone solution if the secondary has reason to place equivalent trust in channel authentication as data authentication e.g. the same operator runs both the primary and secondary.</li>
+  <li>Using TSIG, Strict TLS and an ACL on the primary provides all 3 properties for both parties with probably the lowest operational overhead.</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.7"><a href="#rfc.section.7">7.</a> <a href="#policies-for-both-axfr-and-ixfr" id="policies-for-both-axfr-and-ixfr">Policies for Both AXFR and IXFR</a></h1>
+<p id="rfc.section.7.p.1">We call the entire group of servers involved in XFR (all the primaries and all the secondaries) the 'transfer group'.  </p>
+<p id="rfc.section.7.p.2">Within any transfer group both AXFRs and IXFRs for a zone SHOULD all use the same policy e.g. if AXFRs use AXoT all IXFRs SHOULD use IXoT.  </p>
+<p id="rfc.section.7.p.3">In order to assure the confidentiality of the zone information, the entire transfer group MUST have a consistent policy of requiring confidentiality. If any do not, this is a weak link for attackers to exploit.  </p>
+<p id="rfc.section.7.p.4">A XoT policy should specify </p>
+<p/>
+
+<ul>
+  <li>If TSIG is required</li>
+  <li>What kind of TLS is required (Opportunistic, Strict or mTLS)</li>
+  <li>If IP based ACLs should also be used.</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.7.p.6">Since this may require configuration of a number of servers who may be under the control of different operators the desired consistency could be hard to enforce and audit in practice.  </p>
+<p id="rfc.section.7.p.7">Certain aspects of the Policies can be relatively easily tested independently e.g. by requesting zone transfers without TSIG, from unauthorized IP addresses or over cleartext DNS. Other aspects such as if a secondary will accept data without a TSIG digest or if secondaries are using Strict as opposed to Opportunistic TLS are more challenging.  </p>
+<p id="rfc.section.7.p.8">NOTE: The authors request feedback on this challenge and welcome suggestions of how to practically manage this.  </p>
+<h1 id="rfc.section.8"><a href="#rfc.section.8">8.</a> <a href="#multiprimary-configurations" id="multiprimary-configurations">Multi-primary Configurations</a></h1>
+<p id="rfc.section.8.p.1">Also known as multi-master configurations this model can provide flexibility and redundancy particularly for IXFR. A secondary will receive one or more NOTIFY messages and can send an SOA to all of the configured primaries. It can then choose to send an IXFR request to the primary with the highest SOA (or other criteria e.g. RTT).  </p>
+<p id="rfc.section.8.p.2">When using persistent connections the secondary may have a TLS connection already open to one or more primaries. Should a secondary preferentially request an IXFR from a primary to which it already has an open TLS connection or the one with the highest SOA (assuming it doesn't have a connection open to it already)? </p>
+<p id="rfc.section.8.p.3">Two extremes can be envisaged here. In the first case the secondary continues to use one persistent connection to a single primary until it has reason not to.  Reasons not to might include the primary repeatedly closing the connection, long RTTs on transfers or the SOA of the primary being an unacceptable lag behind the SOA of an alternative primary.  </p>
+<p id="rfc.section.8.p.4">At the other extreme a primary could keep multiple persistent connections open to all available primaries and only request IXFRs from the primary with the highest serial number. Since normally the number of secondaries and primaries in direct contact in a transfer group is reasonably low this might be feasible if latency is the most significant concern.  </p>
+<h1 id="rfc.section.9"><a href="#rfc.section.9">9.</a> <a href="#implementation-considerations" id="implementation-considerations">Implementation Considerations</a></h1>
+<p id="rfc.section.9.p.1">TBD </p>
+<h1 id="rfc.section.10"><a href="#rfc.section.10">10.</a> <a href="#implementation-status" id="implementation-status">Implementation Status</a></h1>
+<p id="rfc.section.10.p.1">The 1.9.2 version of <a href="https://github.com/NLnetLabs/unbound/blob/release-1.9.2/doc/Changelog">Unbound</a> includes an option to perform AXFR-over-TLS (instead of TCP). This requires the client (secondary) to authenticate the server (primary) using a configured authentication domain name.  </p>
+<p id="rfc.section.10.p.2">It is noted that use of a TLS proxy in front of the primary server is a simple deployment solution that can enable server side XoT.  </p>
+<h1 id="rfc.section.11"><a href="#rfc.section.11">11.</a> <a href="#iana-considerations" id="iana-considerations">IANA Considerations</a></h1>
+<p id="rfc.section.11.p.1">TBD </p>
+<h1 id="rfc.section.12"><a href="#rfc.section.12">12.</a> <a href="#security-considerations" id="security-considerations">Security Considerations</a></h1>
+<p id="rfc.section.12.p.1">This document specifies a security measure against a DNS risk: the risk that an attacker collects entire DNS zones through eavesdropping on clear text DNS zone transfers. It presents a new Security Consideration for DNS. Some questions to discuss are: </p>
+<p/>
+
+<ul>
+  <li>Should DoT in this new case be required to use only TLS 1.3 and higher to avoid residual exposure?</li>
+  <li>How should padding be used in IXFR?</li>
+  <li>Should there be an option to 'pad' an AXFR response (i.e. a set of AXFR responses on a given connection) to hide the zone size?</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.section.13"><a href="#rfc.section.13">13.</a> <a href="#acknowledgements" id="acknowledgements">Acknowledgements</a></h1>
+<p id="rfc.section.13.p.1">The authors thank Benno Overeinder, Shumon Huque and Tim Wicinski for review and discussions.  </p>
+<h1 id="rfc.section.14"><a href="#rfc.section.14">14.</a> <a href="#changelog" id="changelog">Changelog</a></h1>
+<p id="rfc.section.14.p.1">draft-ietf-dprive-xfr-over-tls-00 </p>
+<p/>
+
+<ul>
+  <li>Rename after adoption and reference update.</li>
+  <li>Add placeholder for SIG(0) discussion</li>
+  <li>Update section on ZONEMD</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.14.p.3">draft-hzpa-dprive-xfr-over-tls-02 </p>
+<p/>
+
+<ul>
+  <li>Substantial re-work of the document.</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.14.p.5">draft-hzpa-dprive-xfr-over-tls-01 </p>
+<p/>
+
+<ul>
+  <li>Editorial changes, updates to references.</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.14.p.7">draft-hzpa-dprive-xfr-over-tls-00 </p>
+<p/>
+
+<ul>
+  <li>Initial commit</li>
+</ul>
+
+<p> </p>
+<h1 id="rfc.references"><a href="#rfc.references">15.</a> References</h1>
+<h1 id="rfc.references.1"><a href="#rfc.references.1">15.1.</a> Normative References</h1>
+<table>
+  <tbody>
+    <tr>
+      <td class="reference">
+        <b id="I-D.ietf-dprive-rfc7626-bis">[I-D.ietf-dprive-rfc7626-bis]</b>
+      </td>
+      <td class="top"><a>Bortzmeyer, S.</a> and <a>S. Dickinson</a>, "<a href="http://tools.ietf.org/html/draft-ietf-dprive-rfc7626-bis-05">DNS Privacy Considerations</a>", Internet-Draft draft-ietf-dprive-rfc7626-bis-05, May 2020.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="I-D.vcelak-nsec5">[I-D.vcelak-nsec5]</b>
+      </td>
+      <td class="top"><a>Vcelak, J.</a>, <a>Goldberg, S.</a>, <a>Papadopoulos, D.</a>, <a>Huque, S.</a> and <a>D. Lawrence</a>, "<a href="http://tools.ietf.org/html/draft-vcelak-nsec5-08">NSEC5, DNSSEC Authenticated Denial of Existence</a>", Internet-Draft draft-vcelak-nsec5-08, December 2018.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC1995">[RFC1995]</b>
+      </td>
+      <td class="top"><a>Ohta, M.</a>, "<a href="http://tools.ietf.org/html/rfc1995">Incremental Zone Transfer in DNS</a>", RFC 1995, DOI 10.17487/RFC1995, August 1996.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC2119">[RFC2119]</b>
+      </td>
+      <td class="top"><a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC2845">[RFC2845]</b>
+      </td>
+      <td class="top"><a>Vixie, P.</a>, <a>Gudmundsson, O.</a>, <a>Eastlake 3rd, D.</a> and <a>B. Wellington</a>, "<a href="http://tools.ietf.org/html/rfc2845">Secret Key Transaction Authentication for DNS (TSIG)</a>", RFC 2845, DOI 10.17487/RFC2845, May 2000.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC5077">[RFC5077]</b>
+      </td>
+      <td class="top"><a>Salowey, J.</a>, <a>Zhou, H.</a>, <a>Eronen, P.</a> and <a>H. Tschofenig</a>, "<a href="http://tools.ietf.org/html/rfc5077">Transport Layer Security (TLS) Session Resumption without Server-Side State</a>", RFC 5077, DOI 10.17487/RFC5077, January 2008.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC5155">[RFC5155]</b>
+      </td>
+      <td class="top"><a>Laurie, B.</a>, <a>Sisson, G.</a>, <a>Arends, R.</a> and <a>D. Blacka</a>, "<a href="http://tools.ietf.org/html/rfc5155">DNS Security (DNSSEC) Hashed Authenticated Denial of Existence</a>", RFC 5155, DOI 10.17487/RFC5155, March 2008.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC5936">[RFC5936]</b>
+      </td>
+      <td class="top"><a>Lewis, E.</a> and <a>A. Hoenes</a>, "<a href="http://tools.ietf.org/html/rfc5936">DNS Zone Transfer Protocol (AXFR)</a>", RFC 5936, DOI 10.17487/RFC5936, June 2010.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC6973">[RFC6973]</b>
+      </td>
+      <td class="top"><a>Cooper, A.</a>, <a>Tschofenig, H.</a>, <a>Aboba, B.</a>, <a>Peterson, J.</a>, <a>Morris, J.</a>, <a>Hansen, M.</a> and <a>R. Smith</a>, "<a href="http://tools.ietf.org/html/rfc6973">Privacy Considerations for Internet Protocols</a>", RFC 6973, DOI 10.17487/RFC6973, July 2013.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC7858">[RFC7858]</b>
+      </td>
+      <td class="top"><a>Hu, Z.</a>, <a>Zhu, L.</a>, <a>Heidemann, J.</a>, <a>Mankin, A.</a>, <a>Wessels, D.</a> and <a>P. Hoffman</a>, "<a href="http://tools.ietf.org/html/rfc7858">Specification for DNS over Transport Layer Security (TLS)</a>", RFC 7858, DOI 10.17487/RFC7858, May 2016.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC8174">[RFC8174]</b>
+      </td>
+      <td class="top"><a>Leiba, B.</a>, "<a href="http://tools.ietf.org/html/rfc8174">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a>", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC8310">[RFC8310]</b>
+      </td>
+      <td class="top"><a>Dickinson, S.</a>, <a>Gillmor, D.</a> and <a>T. Reddy</a>, "<a href="http://tools.ietf.org/html/rfc8310">Usage Profiles for DNS over TLS and DNS over DTLS</a>", RFC 8310, DOI 10.17487/RFC8310, March 2018.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC8484">[RFC8484]</b>
+      </td>
+      <td class="top"><a>Hoffman, P.</a> and <a>P. McManus</a>, "<a href="http://tools.ietf.org/html/rfc8484">DNS Queries over HTTPS (DoH)</a>", RFC 8484, DOI 10.17487/RFC8484, October 2018.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC8499">[RFC8499]</b>
+      </td>
+      <td class="top"><a>Hoffman, P.</a>, <a>Sullivan, A.</a> and <a>K. Fujiwara</a>, "<a href="http://tools.ietf.org/html/rfc8499">DNS Terminology</a>", BCP 219, RFC 8499, DOI 10.17487/RFC8499, January 2019.</td>
+    </tr>
+  </tbody>
+</table>
+<h1 id="rfc.references.2"><a href="#rfc.references.2">15.2.</a> Informative References</h1>
+<table>
+  <tbody>
+    <tr>
+      <td class="reference">
+        <b id="I-D.ietf-dnsop-dns-zone-digest">[I-D.ietf-dnsop-dns-zone-digest]</b>
+      </td>
+      <td class="top"><a>Wessels, D.</a>, <a>Barber, P.</a>, <a>Weinberg, M.</a>, <a>Kumari, W.</a> and <a>W. Hardaker</a>, "<a href="http://tools.ietf.org/html/draft-ietf-dnsop-dns-zone-digest-07">Message Digest for DNS Zones</a>", Internet-Draft draft-ietf-dnsop-dns-zone-digest-07, April 2020.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC1034">[RFC1034]</b>
+      </td>
+      <td class="top"><a>Mockapetris, P.</a>, "<a href="http://tools.ietf.org/html/rfc1034">Domain names - concepts and facilities</a>", STD 13, RFC 1034, DOI 10.17487/RFC1034, November 1987.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC1035">[RFC1035]</b>
+      </td>
+      <td class="top"><a>Mockapetris, P.</a>, "<a href="http://tools.ietf.org/html/rfc1035">Domain names - implementation and specification</a>", STD 13, RFC 1035, DOI 10.17487/RFC1035, November 1987.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC1982">[RFC1982]</b>
+      </td>
+      <td class="top"><a>Elz, R.</a> and <a>R. Bush</a>, "<a href="http://tools.ietf.org/html/rfc1982">Serial Number Arithmetic</a>", RFC 1982, DOI 10.17487/RFC1982, August 1996.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC1996">[RFC1996]</b>
+      </td>
+      <td class="top"><a>Vixie, P.</a>, "<a href="http://tools.ietf.org/html/rfc1996">A Mechanism for Prompt Notification of Zone Changes (DNS NOTIFY)</a>", RFC 1996, DOI 10.17487/RFC1996, August 1996.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC5953">[RFC5953]</b>
+      </td>
+      <td class="top"><a>Hardaker, W.</a>, "<a href="http://tools.ietf.org/html/rfc5953">Transport Layer Security (TLS) Transport Model for the Simple Network Management Protocol (SNMP)</a>", RFC 5953, DOI 10.17487/RFC5953, August 2010.</td>
+    </tr>
+    <tr>
+      <td class="reference">
+        <b id="RFC7766">[RFC7766]</b>
+      </td>
+      <td class="top"><a>Dickinson, J.</a>, <a>Dickinson, S.</a>, <a>Bellis, R.</a>, <a>Mankin, A.</a> and <a>D. Wessels</a>, "<a href="http://tools.ietf.org/html/rfc7766">DNS Transport over TCP - Implementation Requirements</a>", RFC 7766, DOI 10.17487/RFC7766, March 2016.</td>
+    </tr>
+  </tbody>
+</table>
+<h1 id="rfc.authors">
+  <a href="#rfc.authors">Authors' Addresses</a>
+</h1>
+<div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Han Zhang</span> 
+	  <span class="n hidden">
+		<span class="family-name">Zhang</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Salesforce</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality">San Francisco, CA</span>,  
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">United States</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:hzhang@salesforce.com">hzhang@salesforce.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Pallavi Aras</span> 
+	  <span class="n hidden">
+		<span class="family-name">Aras</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Salesforce</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality">Herndon, VA</span>,  
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">United States</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:paras@salesforce.com">paras@salesforce.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Willem Toorop</span> 
+	  <span class="n hidden">
+		<span class="family-name">Toorop</span>
+	  </span>
+	</span>
+	<span class="org vcardline">NLnet Labs</span>
+	<span class="adr">
+	  <span class="vcardline">Science Park 400</span>
+
+	  <span class="vcardline">
+		<span class="locality">Amsterdam</span>,  
+		<span class="region"></span>
+		<span class="code">1098 XH</span>
+	  </span>
+	  <span class="country-name vcardline">The Netherlands</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:willem@nlnetlabs.nl">willem@nlnetlabs.nl</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Sara Dickinson</span> 
+	  <span class="n hidden">
+		<span class="family-name">Dickinson</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Sinodun IT</span>
+	<span class="adr">
+	  <span class="vcardline">Magdalen Centre</span>
+<span class="vcardline">Oxford Science Park</span>
+
+	  <span class="vcardline">
+		<span class="locality">Oxford</span>,  
+		<span class="region"></span>
+		<span class="code">OX4 4GA</span>
+	  </span>
+	  <span class="country-name vcardline">United Kingdom</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:sara@sinodun.com">sara@sinodun.com</a></span>
+
+  </address>
+</div><div class="avoidbreak">
+  <address class="vcard">
+	<span class="vcardline">
+	  <span class="fn">Allison Mankin</span> 
+	  <span class="n hidden">
+		<span class="family-name">Mankin</span>
+	  </span>
+	</span>
+	<span class="org vcardline">Salesforce</span>
+	<span class="adr">
+	  
+	  <span class="vcardline">
+		<span class="locality">Herndon, VA</span>,  
+		<span class="region"></span>
+		<span class="code"></span>
+	  </span>
+	  <span class="country-name vcardline">United States</span>
+	</span>
+	<span class="vcardline">EMail: <a href="mailto:allison.mankin@gmail.com">allison.mankin@gmail.com</a></span>
+
+  </address>
+</div>
+
+</body>
+</html>

--- a/draft-ietf-dprive-xfr-over-tls-01.txt
+++ b/draft-ietf-dprive-xfr-over-tls-01.txt
@@ -1,0 +1,1064 @@
+
+
+
+
+dprive                                                          H. Zhang
+Internet-Draft                                                   P. Aras
+Updates: 1995 (if approved)                                   Salesforce
+Intended status: Standards Track                               W. Toorop
+Expires: November 20, 2020                                    NLnet Labs
+                                                            S. Dickinson
+                                                              Sinodun IT
+                                                               A. Mankin
+                                                              Salesforce
+                                                            May 19, 2020
+
+
+                       DNS Zone Transfer-over-TLS
+                   draft-ietf-dprive-xfr-over-tls-01
+
+Abstract
+
+   DNS zone transfers are transmitted in clear text, which gives
+   attackers the opportunity to collect the content of a zone by
+   eavesdropping on network connections.  The DNS Transaction Signature
+   (TSIG) mechanism is specified to restrict direct zone transfer to
+   authorized clients only, but it does not add confidentiality.  This
+   document specifies use of DNS-over-TLS to prevent zone contents
+   collection via passive monitoring of zone transfers.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at http://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on November 20, 2020.
+
+Copyright Notice
+
+   Copyright (c) 2020 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+
+
+
+
+Zhang, et al.           Expires November 20, 2020               [Page 1]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  Use Cases for XFR-over-TLS  . . . . . . . . . . . . . . . . .   4
+   4.  Connection and Data Flows in Existing XFR Mechanisms  . . . .   5
+     4.1.  AXFR Mechanism  . . . . . . . . . . . . . . . . . . . . .   5
+     4.2.  IXFR Mechanism  . . . . . . . . . . . . . . . . . . . . .   6
+     4.3.  Data Leakage of NOTIFY and SOA Message Exchanges  . . . .   7
+       4.3.1.  NOTIFY  . . . . . . . . . . . . . . . . . . . . . . .   7
+       4.3.2.  SOA . . . . . . . . . . . . . . . . . . . . . . . . .   8
+   5.  Connection and Data Flows in XoT  . . . . . . . . . . . . . .   8
+     5.1.  Performance Considerations  . . . . . . . . . . . . . . .   8
+     5.2.  AXoT mechanism  . . . . . . . . . . . . . . . . . . . . .   8
+     5.3.  IXoT mechanism  . . . . . . . . . . . . . . . . . . . . .   9
+       5.3.1.  Fallback to AXFR  . . . . . . . . . . . . . . . . . .  10
+   6.  Zone Transfer with DoT - Authentication . . . . . . . . . . .  10
+     6.1.  TSIG  . . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     6.2.  SIG(0)  . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     6.3.  TLS . . . . . . . . . . . . . . . . . . . . . . . . . . .  10
+       6.3.1.  Opportunistic . . . . . . . . . . . . . . . . . . . .  10
+       6.3.2.  Strict  . . . . . . . . . . . . . . . . . . . . . . .  11
+       6.3.3.  Mutual  . . . . . . . . . . . . . . . . . . . . . . .  11
+     6.4.  IP Based ACL on the Primary . . . . . . . . . . . . . . .  11
+     6.5.  ZONEMD  . . . . . . . . . . . . . . . . . . . . . . . . .  11
+     6.6.  Comparison of Authentication Methods  . . . . . . . . . .  12
+   7.  Policies for Both AXFR and IXFR . . . . . . . . . . . . . . .  13
+   8.  Multi-primary Configurations  . . . . . . . . . . . . . . . .  13
+   9.  Implementation Considerations . . . . . . . . . . . . . . . .  14
+   10. Implementation Status . . . . . . . . . . . . . . . . . . . .  14
+   11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
+   12. Security Considerations . . . . . . . . . . . . . . . . . . .  14
+   13. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  15
+   14. Changelog . . . . . . . . . . . . . . . . . . . . . . . . . .  15
+   15. References  . . . . . . . . . . . . . . . . . . . . . . . . .  15
+     15.1.  Normative References . . . . . . . . . . . . . . . . . .  15
+     15.2.  Informative References . . . . . . . . . . . . . . . . .  17
+     15.3.  URIs . . . . . . . . . . . . . . . . . . . . . . . . . .  18
+
+
+
+Zhang, et al.           Expires November 20, 2020               [Page 2]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  18
+
+1.  Introduction
+
+   DNS has a number of privacy vulnerabilities, as discussed in detail
+   in [I-D.ietf-dprive-rfc7626-bis].  Stub client to recursive resolver
+   query privacy has received the most attention to date.  There are now
+   standards track documents for three encryption capabilities for stub
+   to recursive queries and more work going on to guide deployment of
+   specifically DNS-over-TLS (DoT) [RFC7858] and DNS-over-HTTPS (DoH)
+   [RFC8484].
+
+   [I-D.ietf-dprive-rfc7626-bis] established that stub client DNS query
+   transactions are not public and needed protection, but on zone
+   transfer [RFC1995] [RFC5936] it says only:
+
+   "Privacy risks for the holder of a zone (the risk that someone gets
+   the data) are discussed in [RFC5936] and [RFC5155]."
+
+   In what way is exposing the full contents of a zone a privacy risk?
+   The contents of the zone could include information such as names of
+   persons used in names of hosts.  Best practice is not to use personal
+   information for domain names, but many such domain names exist.
+   There may also be regulatory, policy or other reasons why the zone
+   contents in full must be treated as private.
+
+   Neither of the RFCs mentioned in [I-D.ietf-dprive-rfc7626-bis]
+   contemplates the risk that someone gets the data through
+   eavesdropping on network connections, only via enumeration or
+   unauthorized transfer as described in the following paragraphs.
+
+   [RFC5155] specifies NSEC3 to prevent zone enumeration, which is when
+   queries for the authenticated denial of existences records of DNSSEC
+   allow a client to walk through the entire zone.  Note that the need
+   for this protection also motivates NSEC5 [I-D.vcelak-nsec5]; zone
+   walking is now possible with NSEC3 due to crypto-breaking advances,
+   and NSEC5 is a response to this problem.
+
+   [RFC5155] does not address data obtained outside zone enumeration
+   (nor does [I-D.vcelak-nsec5]).  Preventing eavesdropping of zone
+   transfers (this draft) is orthogonal to preventing zone enumeration,
+   though they aim to protect the same information.
+
+   [RFC5936] specifies using TSIG [RFC2845] for authorization of the
+   clients of a zone transfer and for data integrity, but does not
+   express any need for confidentiality, and TSIG does not offer
+   encryption.  Some operators use SSH tunneling or IPSec to encrypt the
+   transfer data.
+
+
+
+Zhang, et al.           Expires November 20, 2020               [Page 3]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   Because the AXFR zone transfer is typically carried out-over-TCP from
+   authoritative DNS protocol implementations, encrypting AXFR using
+   DNS-over-TLS [RFC7858] seems like a simple step forward.  This
+   document specifies how to use DoT to prevent zone collection from
+   zone transfers, including discussion of approaches for IXFR, which
+   uses UDP or TCP.
+
+2.  Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] and [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+   Privacy terminology is as described in Section 3 of [RFC6973].
+
+   Note that in this document we choose to use the terms 'primary' and
+   'secondary' for two servers engaged in zone transfers.
+
+   DNS terminology is as described in [RFC8499].
+
+   DoT: DNS-over-TLS as specified in [RFC7858]
+
+   XoT: Generic XFR-over-TLS mechanisms as specified in this document
+
+   AXoT: AXFR-over-TLS
+
+   IXoT: IXFR over-TLS
+
+3.  Use Cases for XFR-over-TLS
+
+   o  Confidentiality.  Clearly using an encrypted transport for zone
+      transfers will defeat zone content leakage that can occur via
+      passive surveillance.
+
+   o  Authentication.  Use of single or mutual TLS authentication (in
+      combination with ACLs) can complement and potentially be an
+      alternative to TSIG.
+
+   o  Performance.  Existing AXFR and IXFR mechanisms have the burden of
+      backwards compatibility with older implementations based on the
+      original specifications in [RFC1034] and [RFC1035].  For example,
+      some older AXFR servers don't support using a TCP connection for
+      multiple AXFR sessions or XFRs of different zones because they
+      have not been updated to follow the guidance in [RFC5936].  Any
+      implementation of XFR-over-TLS would obviously be required to
+
+
+
+
+Zhang, et al.           Expires November 20, 2020               [Page 4]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+      implement optimized and interoperable transfers as described in
+      [RFC5936] e.g. transfer of multiple zones over one connection.
+
+   o  Performance.  Current usage of TCP for IXFR is sub-optimal in some
+      cases i.e.  connections are frequently closed after a single IXFR.
+
+4.  Connection and Data Flows in Existing XFR Mechanisms
+
+   The original specification for zone transfers in [RFC1034] and
+   [RFC1035] was based on a polling mechanism: a secondary performed a
+   periodic SOA query (based on the refresh timer) to determine if an
+   AXFR was required.
+
+   [RFC1995] and [RFC1996] introduced the concepts of IXFR and NOTIFY
+   respectively, to provide for prompt propagation of zone updates.
+   This has largely replaced AXFR where possible, particularly for
+   dynamically updated zones.
+
+   [RFC5936] subsequently redefined the specification of AXFR to improve
+   performance and interoperability.
+
+   In this document we use the phrase "XFR mechanism" to describe the
+   entire set of message exchanges between a secondary and a primary
+   that concludes in a successful AXFR or IXFR request/response.  This
+   set may or may not include
+
+   o  NOTIFY messages
+
+   o  SOA queries
+
+   o  Fallback from IXFR to AXFR
+
+   o  Fallback from IXFR-over-UDP to IXFR-over-TCP
+
+   The term is used to encompasses the range of permutations that are
+   possible and is useful to distinguish the 'XFR mechanism' from a
+   single XFR request/response exchange.
+
+4.1.  AXFR Mechanism
+
+   The figure below provides an outline of an AXFR mechanism including
+   NOTIFYs.
+
+   Figure 1.  AXFR Mechanism [1]
+
+   1.  An AXFR is often (but not always) preceded by a NOTIFY (over UDP)
+       from the primary to the secondary.  A secondary may also initiate
+
+
+
+
+Zhang, et al.           Expires November 20, 2020               [Page 5]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+       an AXFR based on a refresh timer or scheduled/triggered zone
+       maintenance.
+
+   2.  The secondary will normally (but not always) make a SOA query to
+       the primary to obtain the serial number of the zone held by the
+       primary.
+
+   3.  If the primary serial is higher than the secondaries serial
+       (using Serial Number Arithmetic [RFC1982]), the secondary makes
+       an AXFR request (over TCP) to the primary after which the AXFR
+       data flows in one or more AXFR responses on the TCP connection.
+
+   [RFC5936] specifies that AXFR must use TCP as the transport protocol
+   but details that there is no restriction in the protocol that a
+   single TCP session must be used only for a single AXFR exchange, or
+   even solely for XFRs.  For example, it outlines that the SOA query
+   can also happen on this connection.  However, this can cause
+   interoperability problems with older implementations that support
+   only the trivial case of one AXFR per connection.
+
+   Further details of the limitations in existing AXFR implementations
+   are outlined in [RFC5936].
+
+   It is noted that unless the NOTIFY is sent over a trusted
+   communication channel and/or signed by TSIG is can be spoofed causing
+   unnecessary zone transfer attempts.
+
+   Similarly unless the SOA query is sent over a trusted communication
+   channel and/or signed by TSIG the response can, in principle, be
+   spoofed causing a secondary to incorrectly believe its version of the
+   zone is update to date.  Repeated successful attacks on the SOA could
+   result in a secondary serving stale zone data.
+
+4.2.  IXFR Mechanism
+
+   The figure below provides an outline of the IXFR mechanism including
+   NOTIFYs.
+
+   Figure 1.  IXFR Mechanism [2]
+
+   1.  An IXFR is normally (but not always) preceded by a NOTIFY (over
+       UDP) from the primary to the secondary.  A secondary may also
+       initiate an IXFR based on a refresh timer or scheduled/triggered
+       zone maintenance.
+
+   2.  The secondary will normally (but not always) make a SOA query to
+       the primary to obtain the serial number of the zone held by the
+       primary.
+
+
+
+Zhang, et al.           Expires November 20, 2020               [Page 6]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   3.  If the primary serial is higher than the secondaries serial
+       (using Serial Number Arithmetic [RFC1982]), the secondary makes
+       an IXFR request to the primary after the primary sends an IXFR
+       response.
+
+   [RFC1995] specifies that Incremental Transfer may use UDP if the
+   entire IXFR response can be contained in a single DNS packet,
+   otherwise, TCP is used.  In fact is says in non-normative language:
+
+   "Thus, a client should first make an IXFR query using UDP."
+
+   So there may be a forth step above where the client falls back to
+   IXFR-over-TCP.  There may also be a forth step where the secondary
+   must fall back to AXFR because e.g. the primary does not support
+   IXFR.
+
+   However it is noted that at least two widely used open source
+   authoritative nameserver implementations (BIND [3] and NSD [4]) do
+   IXFR using TCP by default in their latest releases.  For BIND TCP
+   connections are sometimes used for SOA queries but in general they
+   are not used persistently and close after an IXFR is completed.
+
+   It is noted that the specification for IXFR was published well before
+   TCP was considered a first class transport for DNS.  This document
+   therefore updates [RFC1995] to state that DNS implementations that
+   support IXFR-over-TCP MUST use [RFC7766] to optimise the use of TCP
+   connections and SHOULD use [RFC7858] to manage persistent
+   connections.
+
+4.3.  Data Leakage of NOTIFY and SOA Message Exchanges
+
+   This section attempts to presents a rationale for also encrypting the
+   other messages in the XFR mechanism.
+
+   Since the SOA of the published zone can be trivially discovered by
+   simply querying the publicly available authoritative servers leakage
+   of this RR is not discussed in the following sections.
+
+4.3.1.  NOTIFY
+
+   Unencrypted NOTIFY messages identify configured secondaries on the
+   primary.
+
+   [RFC1996] also states:
+
+   "If ANCOUNT>0, then the answer section represents an unsecure hint at
+   the new RRset for this .
+
+
+
+
+Zhang, et al.           Expires November 20, 2020               [Page 7]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   But since the only supported QTYPE for NOTIFY is SOA, this does not
+   pose a potential leak.
+
+4.3.2.  SOA
+
+   For hidden primaries or secondaries the SOA response leaks the degree
+   of lag of any downstream secondary.
+
+5.  Connection and Data Flows in XoT
+
+5.1.  Performance Considerations
+
+   The details in [RFC7766], [RFC7858] and [RFC8310] about e.g. using
+   persistent connections and TLS Session Resumption [RFC5077] are fully
+   applicable to XFR-over-TLS as well.
+
+   It is RECOMMENDED that clients and servers that support XoT also
+   implement EDNS0 Keepalive [RFC7828].
+
+   It is useful to note that in these mechanisms is it the secondary
+   that initiates the TLS connection to the primary for a XFR request,
+   so that in terms of connectivity the secondary is the TLS client and
+   the primary the TLS server.
+
+5.2.  AXoT mechanism
+
+   The figure below provides an outline of the AXoT mechanism including
+   NOTIFYs.
+
+   Figure 3: AXoT mechanism [5]
+
+   The connection for AXFR-over-TLS SHOULD be established using port
+   853, as specified in [RFC7858], unless there is mutual agreement
+   between the secondary and primary to use a port other than port 853
+   for XFR-over-TLS.
+
+   All implementations that support XoT MUST fully implement [RFC5953]
+   behavior on TLS connections.
+
+   Sections 4.1, 4.1.1 and 4.1.2 of [RFC5936] describe guidance for AXFR
+   clients and servers with regard to re-use of sessions for multiple
+   AXFRs, AXFRs of different zones and using TCP session for other
+   queries including SOA.
+
+   For clarity we restate here that an AXoT client MAY use an already
+   opened TLS connection to send a AXFR request.  Using an existing open
+   connection is RECOMMENDED over opening a new connection.  (Non-AXoT
+   session traffic can also use an open connection.)
+
+
+
+Zhang, et al.           Expires November 20, 2020               [Page 8]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   For clarity we additionally state here that an AXoT client MAY use an
+   already opened TLS connection to send a SOA request.  Using an
+   existing open connection is RECOMMENDED over opening a new
+   connection.
+
+   QUESTION: Should there be a requirement that the SOA is always done
+   on a TLS connection if the XFR is?  For the case when no transfer is
+   required this could be unnecessary overhead.
+
+5.3.  IXoT mechanism
+
+   The figure below provides an outline of the IXoT mechanism including
+   NOTIFYs.
+
+   Figure 4: IXoT mechanism [6]
+
+   The connection for IXFR-over-TLS SHOULD be established using port
+   853, as specified in [RFC7858], unless there is mutual agreement
+   between the secondary and primary to use a port other than port 853
+   for XFR-over-TLS.
+
+   [RFC1995] says nothing with respect to optimizing IXFRs over TCP or
+   re-using already open TCP connections to perform IXFRs or other
+   queries.  We provide guidance here that aligns with the guidance in
+   [RFC5936] for AXFR and with that for performant TCP/TLS usage in
+   [RFC7766] and [RFC7858].
+
+   An IXoT client MAY use an already opened TLS connection to send a
+   IXFR request.  Using an existing open connection is RECOMMENDED over
+   opening a new connection.  (Non-IXoT session traffic can also use an
+   open connection.)
+
+   An IXoT client MAY use an already open TLS connection to send an SOA
+   query.  Using an existing open connection is RECOMMENDED over opening
+   a new connection.
+
+   An IXoT server MUST be able to handle multiple IXoT requests on a
+   single TLS connection, as well as to handle other query/response
+   transactions over it.
+
+   An IXoT client MAY keep an existing TLS session open in the
+   expectation it is likely to need to perform an IXFR in the near
+   future.  The client may use the frequency of recent IXFRs to
+   calculate an average update rate and then use EDNS0 Keepalive to
+   request an appropriate timeout from the server (if the server
+   supports EDNS0 Keepalive).  If the server does not support EDNS0
+   Keepalive the client MAY keep the connection open for a few seconds
+
+
+
+
+Zhang, et al.           Expires November 20, 2020               [Page 9]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   ([RFC7766] recommends that servers use timeouts of at least a few
+   seconds).
+
+   An IXoT client MAY pipeline IXFR requests for different zones on a
+   single TLS connection.  AN IXoT server MAY respond to those requests
+   out of order.
+
+   QUESTION: Since this is a new specification should there be a
+   requirement that IXoT servers are RECOMMENDED to condense responses
+   as described in Section 6 of [RFC1995].  [RFC1995] document says this
+   is optional and MAY be done but it can significantly reduce the size
+   of responses and may have implications for padding?
+
+5.3.1.  Fallback to AXFR
+
+   Fallback to AXFR can happen, for example, if the server is not able
+   to provide an IXFR for the requested SOA.  Implementations differ in
+   how long they store zone deltas and how many may be stored at any one
+   time.
+
+   After a failed IXFR a IXoT client SHOULD request the AXFR on the
+   already open TLS connection.
+
+6.  Zone Transfer with DoT - Authentication
+
+6.1.  TSIG
+
+   TSIG [RFC2845] provides a mechanism for two parties to exchange
+   secret keys which can then be used to create a message digest to
+   protect individual DNS messages.  This allows each party to
+   authenticate that a request or response (and the data in it) came
+   from the other party, even if it was transmitted-over-an unsecured
+   channel or via a proxy.  It provides party-to-party data
+   authentication, but not hop-to-hop channel authentication or
+   confidentiality.
+
+6.2.  SIG(0)
+
+   TBD
+
+6.3.  TLS
+
+6.3.1.  Opportunistic
+
+   Opportunistic TLS [RFC8310] provides a defence against passive
+   surveillance, providing on-the-wire confidentiality.
+
+
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 10]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+6.3.2.  Strict
+
+   Strict TLS [RFC8310] requires that a client is configured with an
+   authentication domain name (and/or SPKI pinset) that should be used
+   to authenticate the TLS handshake with the server.  This additionally
+   provides a defense for the client against active surveillance,
+   providing client-to-server authentication and end-to-end channel
+   confidentiality.
+
+6.3.3.  Mutual
+
+   This is an extension to Strict TLS [RFC8310] which requires that a
+   client is configured with an authentication domain name (and/or SPKI
+   pinset) and a client certificate.  The client offers the certificate
+   for authentication by the server and the client can authentic the
+   server the same way as in Strict TLS.  This provides a defense for
+   both parties against active surveillance, providing bi-directional
+   authentication and end-to-end channel confidentiality.
+
+6.4.  IP Based ACL on the Primary
+
+   Most DNS server implementations offer an option to configure an IP
+   based Access Control List (ACL), which is often used in combination
+   with TSIG based ACLs to restrict access to zone transfers on primary
+   servers.
+
+   This is also possible with XoT but it must be noted that as with TCP
+   the implementation of such an ACL cannot be enforced on the primary
+   until a XFR request is received on an established connection.
+
+   If control were to be any more fine-grained than this then a
+   separate, dedicated port would need to be agreed between primary and
+   secondary for XoT such that implementations would be able to refuse
+   connections on that port to all clients except those configured as
+   secondaries.
+
+6.5.  ZONEMD
+
+   Message Digest for DNS Zones (ZONEMD)
+   [I-D.ietf-dnsop-dns-zone-digest] digest is a mechanism that can be
+   used to verify the content of a standalone zone.  It is designed to
+   be independent of the transmission channel or mechanism, allowing a
+   general consumer of a zone to do origin authentication of the entire
+   zone contents.  Note that the current version of
+   [I-D.ietf-dnsop-dns-zone-digest] states:
+
+   "As specified at this time, ZONEMD is not designed for use in large,
+   dynamic zones due to the time and resources required for digest
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 11]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   calculation.  The ZONEMD record described in this document includes
+   fields reserved for future work to support large, dynamic zones."
+
+   It is complementary the above mechanisms and can be used in
+   conjunction with XFR-over-TLS but is not considered further.
+
+6.6.  Comparison of Authentication Methods
+
+   The Table below compares the properties of each of the above methods
+   in terms of what protection they provide to the secondary and primary
+   servers during XoT in terms of:
+
+   o  'Data Auth': Authentication that the DNS message data is signed by
+      the party with whom credentials were shared (the signing party may
+      or may not be party operating the far end of a TCP/TLS connection
+      in a 'proxy' scenario).  For the primary the TSIG on the XFR
+      request confirms that the requesting party is authorized to
+      request zone data, for the secondary it authenticates the zone
+      data that is received.
+
+   o  'Channel Conf': Confidentiality of the communication channel
+      between the client and server (i.e. the two end points of a TCP/
+      TLS connection).
+
+   o  Channel Auth: Authentication of the identity of party to whom a
+      TCP/TLS connection is made (this might not be a direct connection
+      between the primary and secondary in a proxy scenario).
+
+   It is noted that zone transfer scenarios can vary from a simple
+   single primary/secondary relationship where both servers are under
+   the control of a single operator to a complex hierarchical structure
+   which includes proxies and multiple operators.  Each deployment
+   scenario will require specific analysis to determine which
+   authentication methods are best suited to the deployment model in
+   question.
+
+   Table 1: Properties of Authentication methods for XoT [7]
+
+   Based on this analysis it can be seen that:
+
+   o  A combination of Opportunistic TLS and TSIG provides both data
+      authentication and channel confidentiality for both parties.
+      However this does not stop a MitM attack on the channel which
+      could be used to gather zone data.
+
+   o  Using just mutual TLS can be considered a standalone solution if
+      the secondary has reason to place equivalent trust in channel
+
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 12]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+      authentication as data authentication e.g. the same operator runs
+      both the primary and secondary.
+
+   o  Using TSIG, Strict TLS and an ACL on the primary provides all 3
+      properties for both parties with probably the lowest operational
+      overhead.
+
+7.  Policies for Both AXFR and IXFR
+
+   We call the entire group of servers involved in XFR (all the
+   primaries and all the secondaries) the 'transfer group'.
+
+   Within any transfer group both AXFRs and IXFRs for a zone SHOULD all
+   use the same policy e.g. if AXFRs use AXoT all IXFRs SHOULD use IXoT.
+
+   In order to assure the confidentiality of the zone information, the
+   entire transfer group MUST have a consistent policy of requiring
+   confidentiality.  If any do not, this is a weak link for attackers to
+   exploit.
+
+   A XoT policy should specify
+
+   o  If TSIG is required
+
+   o  What kind of TLS is required (Opportunistic, Strict or mTLS)
+
+   o  If IP based ACLs should also be used.
+
+   Since this may require configuration of a number of servers who may
+   be under the control of different operators the desired consistency
+   could be hard to enforce and audit in practice.
+
+   Certain aspects of the Policies can be relatively easily tested
+   independently e.g. by requesting zone transfers without TSIG, from
+   unauthorized IP addresses or over cleartext DNS.  Other aspects such
+   as if a secondary will accept data without a TSIG digest or if
+   secondaries are using Strict as opposed to Opportunistic TLS are more
+   challenging.
+
+   NOTE: The authors request feedback on this challenge and welcome
+   suggestions of how to practically manage this.
+
+8.  Multi-primary Configurations
+
+   Also known as multi-master configurations this model can provide
+   flexibility and redundancy particularly for IXFR.  A secondary will
+   receive one or more NOTIFY messages and can send an SOA to all of the
+
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 13]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   configured primaries.  It can then choose to send an IXFR request to
+   the primary with the highest SOA (or other criteria e.g.  RTT).
+
+   When using persistent connections the secondary may have a TLS
+   connection already open to one or more primaries.  Should a secondary
+   preferentially request an IXFR from a primary to which it already has
+   an open TLS connection or the one with the highest SOA (assuming it
+   doesn't have a connection open to it already)?
+
+   Two extremes can be envisaged here.  In the first case the secondary
+   continues to use one persistent connection to a single primary until
+   it has reason not to.  Reasons not to might include the primary
+   repeatedly closing the connection, long RTTs on transfers or the SOA
+   of the primary being an unacceptable lag behind the SOA of an
+   alternative primary.
+
+   At the other extreme a primary could keep multiple persistent
+   connections open to all available primaries and only request IXFRs
+   from the primary with the highest serial number.  Since normally the
+   number of secondaries and primaries in direct contact in a transfer
+   group is reasonably low this might be feasible if latency is the most
+   significant concern.
+
+9.  Implementation Considerations
+
+   TBD
+
+10.  Implementation Status
+
+   The 1.9.2 version of Unbound [8] includes an option to perform AXFR-
+   over-TLS (instead of TCP).  This requires the client (secondary) to
+   authenticate the server (primary) using a configured authentication
+   domain name.
+
+   It is noted that use of a TLS proxy in front of the primary server is
+   a simple deployment solution that can enable server side XoT.
+
+11.  IANA Considerations
+
+   TBD
+
+12.  Security Considerations
+
+   This document specifies a security measure against a DNS risk: the
+   risk that an attacker collects entire DNS zones through eavesdropping
+   on clear text DNS zone transfers.  It presents a new Security
+   Consideration for DNS.  Some questions to discuss are:
+
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 14]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   o  Should DoT in this new case be required to use only TLS 1.3 and
+      higher to avoid residual exposure?
+
+   o  How should padding be used in IXFR?
+
+   o  Should there be an option to 'pad' an AXFR response (i.e. a set of
+      AXFR responses on a given connection) to hide the zone size?
+
+13.  Acknowledgements
+
+   The authors thank Benno Overeinder, Shumon Huque and Tim Wicinski for
+   review and discussions.
+
+14.  Changelog
+
+   draft-ietf-dprive-xfr-over-tls-00
+
+   o  Rename after adoption and reference update.
+
+   o  Add placeholder for SIG(0) discussion
+
+   o  Update section on ZONEMD
+
+   draft-hzpa-dprive-xfr-over-tls-02
+
+   o  Substantial re-work of the document.
+
+   draft-hzpa-dprive-xfr-over-tls-01
+
+   o  Editorial changes, updates to references.
+
+   draft-hzpa-dprive-xfr-over-tls-00
+
+   o  Initial commit
+
+15.  References
+
+15.1.  Normative References
+
+   [I-D.ietf-dprive-rfc7626-bis]
+              Bortzmeyer, S. and S. Dickinson, "DNS Privacy
+              Considerations", draft-ietf-dprive-rfc7626-bis-05 (work in
+              progress), May 2020.
+
+
+
+
+
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 15]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   [I-D.vcelak-nsec5]
+              Vcelak, J., Goldberg, S., Papadopoulos, D., Huque, S., and
+              D. Lawrence, "NSEC5, DNSSEC Authenticated Denial of
+              Existence", draft-vcelak-nsec5-08 (work in progress),
+              December 2018.
+
+   [RFC1995]  Ohta, M., "Incremental Zone Transfer in DNS", RFC 1995,
+              DOI 10.17487/RFC1995, August 1996, <https://www.rfc-
+              editor.org/info/rfc1995>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
+              editor.org/info/rfc2119>.
+
+   [RFC2845]  Vixie, P., Gudmundsson, O., Eastlake 3rd, D., and B.
+              Wellington, "Secret Key Transaction Authentication for DNS
+              (TSIG)", RFC 2845, DOI 10.17487/RFC2845, May 2000,
+              <https://www.rfc-editor.org/info/rfc2845>.
+
+   [RFC5077]  Salowey, J., Zhou, H., Eronen, P., and H. Tschofenig,
+              "Transport Layer Security (TLS) Session Resumption without
+              Server-Side State", RFC 5077, DOI 10.17487/RFC5077,
+              January 2008, <https://www.rfc-editor.org/info/rfc5077>.
+
+   [RFC5155]  Laurie, B., Sisson, G., Arends, R., and D. Blacka, "DNS
+              Security (DNSSEC) Hashed Authenticated Denial of
+              Existence", RFC 5155, DOI 10.17487/RFC5155, March 2008,
+              <https://www.rfc-editor.org/info/rfc5155>.
+
+   [RFC5936]  Lewis, E. and A. Hoenes, Ed., "DNS Zone Transfer Protocol
+              (AXFR)", RFC 5936, DOI 10.17487/RFC5936, June 2010,
+              <https://www.rfc-editor.org/info/rfc5936>.
+
+   [RFC6973]  Cooper, A., Tschofenig, H., Aboba, B., Peterson, J.,
+              Morris, J., Hansen, M., and R. Smith, "Privacy
+              Considerations for Internet Protocols", RFC 6973,
+              DOI 10.17487/RFC6973, July 2013, <https://www.rfc-
+              editor.org/info/rfc6973>.
+
+   [RFC7858]  Hu, Z., Zhu, L., Heidemann, J., Mankin, A., Wessels, D.,
+              and P. Hoffman, "Specification for DNS over Transport
+              Layer Security (TLS)", RFC 7858, DOI 10.17487/RFC7858, May
+              2016, <https://www.rfc-editor.org/info/rfc7858>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 16]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   [RFC8310]  Dickinson, S., Gillmor, D., and T. Reddy, "Usage Profiles
+              for DNS over TLS and DNS over DTLS", RFC 8310,
+              DOI 10.17487/RFC8310, March 2018, <https://www.rfc-
+              editor.org/info/rfc8310>.
+
+   [RFC8484]  Hoffman, P. and P. McManus, "DNS Queries over HTTPS
+              (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
+              <https://www.rfc-editor.org/info/rfc8484>.
+
+   [RFC8499]  Hoffman, P., Sullivan, A., and K. Fujiwara, "DNS
+              Terminology", BCP 219, RFC 8499, DOI 10.17487/RFC8499,
+              January 2019, <https://www.rfc-editor.org/info/rfc8499>.
+
+15.2.  Informative References
+
+   [I-D.ietf-dnsop-dns-zone-digest]
+              Wessels, D., Barber, P., Weinberg, M., Kumari, W., and W.
+              Hardaker, "Message Digest for DNS Zones", draft-ietf-
+              dnsop-dns-zone-digest-07 (work in progress), April 2020.
+
+   [RFC1034]  Mockapetris, P., "Domain names - concepts and facilities",
+              STD 13, RFC 1034, DOI 10.17487/RFC1034, November 1987,
+              <https://www.rfc-editor.org/info/rfc1034>.
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
+              November 1987, <https://www.rfc-editor.org/info/rfc1035>.
+
+   [RFC1982]  Elz, R. and R. Bush, "Serial Number Arithmetic", RFC 1982,
+              DOI 10.17487/RFC1982, August 1996, <https://www.rfc-
+              editor.org/info/rfc1982>.
+
+   [RFC1996]  Vixie, P., "A Mechanism for Prompt Notification of Zone
+              Changes (DNS NOTIFY)", RFC 1996, DOI 10.17487/RFC1996,
+              August 1996, <https://www.rfc-editor.org/info/rfc1996>.
+
+   [RFC5953]  Hardaker, W., "Transport Layer Security (TLS) Transport
+              Model for the Simple Network Management Protocol (SNMP)",
+              RFC 5953, DOI 10.17487/RFC5953, August 2010,
+              <https://www.rfc-editor.org/info/rfc5953>.
+
+   [RFC7766]  Dickinson, J., Dickinson, S., Bellis, R., Mankin, A., and
+              D. Wessels, "DNS Transport over TCP - Implementation
+              Requirements", RFC 7766, DOI 10.17487/RFC7766, March 2016,
+              <https://www.rfc-editor.org/info/rfc7766>.
+
+
+
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 17]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+15.3.  URIs
+
+   [1] https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/
+       blob/02_updates/02-draft-svg/AXFR_mechanism.svg
+
+   [2] https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/
+       blob/02_updates/02-draft-svg/IXFR%20mechanism.svg
+
+   [3] https://www.isc.org/bind/
+
+   [4] https://www.nlnetlabs.nl/projects/nsd/about/
+
+   [5] https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/
+       blob/02_updates/02-draft-svg/AXoT_mechanism_1.svg
+
+   [6] https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/
+       blob/02_updates/02-draft-svg/IXoT_mechanism_1.svg
+
+   [7] https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/
+       blob/02_updates/02-draft-svg/
+       Properties_of_Authentication_methods_for_XoT.svg
+
+   [8] https://github.com/NLnetLabs/unbound/blob/release-1.9.2/doc/
+       Changelog
+
+Authors' Addresses
+
+   Han Zhang
+   Salesforce
+   San Francisco, CA
+   United States
+
+   Email: hzhang@salesforce.com
+
+
+   Pallavi Aras
+   Salesforce
+   Herndon, VA
+   United States
+
+   Email: paras@salesforce.com
+
+
+
+
+
+
+
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 18]
+
+Internet-Draft                XFR-over-TLS                      May 2020
+
+
+   Willem Toorop
+   NLnet Labs
+   Science Park 400
+   Amsterdam  1098 XH
+   The Netherlands
+
+   Email: willem@nlnetlabs.nl
+
+
+   Sara Dickinson
+   Sinodun IT
+   Magdalen Centre
+   Oxford Science Park
+   Oxford  OX4 4GA
+   United Kingdom
+
+   Email: sara@sinodun.com
+
+
+   Allison Mankin
+   Salesforce
+   Herndon, VA
+   United States
+
+   Email: allison.mankin@gmail.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Zhang, et al.           Expires November 20, 2020              [Page 19]

--- a/draft-ietf-dprive-xfr-over-tls.md
+++ b/draft-ietf-dprive-xfr-over-tls.md
@@ -2,13 +2,13 @@
     Title = "DNS Zone Transfer-over-TLS"
     abbrev = "XFR-over-TLS"
     category = "std"
-    docName= "draft-ietf-dprive-xfr-over-tls-00"
+    docName= "draft-ietf-dprive-xfr-over-tls-01"
     ipr = "trust200902"
     area = "Internet"
     workgroup = "dprive"
     keyword = ["DNS", "operations", "privacy"]
     updates = [1995]
-    date = 2019-11-18T00:00:00Z
+    date = 2020-05-19T00:00:00Z
     [pi]
     [[author]]
      initials="H."
@@ -147,8 +147,6 @@ DNS terminology is as described in [@!RFC8499].
 
 DoT: DNS-over-TLS as specified in [@!RFC7858]
 
-DoH: DNS-over-HTTPS as specified in [@!RFC8484]
-
 XoT: Generic XFR-over-TLS mechanisms as specified in this document
 
 AXoT: AXFR-over-TLS
@@ -170,7 +168,7 @@ IXoT: IXFR over-TLS
   zones because they have not been updated to follow the guidance in [@RFC5936].
   Any implementation of XFR-over-TLS would obviously be required to implement
   optimized and interoperable transfers as described in [@RFC5936] e.g. transfer
-  of multiple zones-over-one connection.
+  of multiple zones over one connection.
   
 * Performance. Current usage of TCP for IXFR is sub-optimal in some cases i.e.
   connections are frequently closed after a single IXFR.
@@ -323,11 +321,17 @@ applicable to XFR-over-TLS as well.
 It is RECOMMENDED that clients and servers that support XoT also implement
 EDNS0 Keepalive [RFC7828].
 
+It is useful to note that in these mechanisms is it the secondary that initiates the TLS connection to the primary for a XFR request, so that in terms of connectivity the secondary is the TLS client and the primary the TLS server.
+
 ## AXoT mechanism
 
 The figure below provides an outline of the AXoT mechanism including NOTIFYs.
 
 [Figure 3: AXoT mechanism](https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/blob/02_updates/02-draft-svg/AXoT_mechanism_1.svg)
+
+The connection for AXFR-over-TLS SHOULD be established using port 853, as
+specified in [@!RFC7858], unless there is mutual agreement between the secondary
+and primary to use a port other than port 853 for XFR-over-TLS.
 
 All implementations that support XoT MUST fully implement [@RFC5953] behavior
 on TLS connections.
@@ -344,10 +348,6 @@ use an open connection.)
 For clarity we additionally state here that an AXoT client MAY use an already
 opened TLS connection to send a SOA request. Using an existing open connection
 is RECOMMENDED over opening a new connection.
-
-The connection for AXFR-over-TLS SHOULD be established using port 853, as
-specified in [@!RFC7858], unless there is mutual agreement between the secondary
-and primary to use a port other than port 853 for XFR-over-TLS.
 
 QUESTION: Should there be a requirement that the SOA is always done on a TLS
 connection if the XFR is? For the case when no transfer is required this could
@@ -389,6 +389,8 @@ recommends that servers use timeouts of at least a few seconds).
 
 An IXoT client MAY pipeline IXFR requests for different zones on a single TLS
 connection. AN IXoT server MAY respond to those requests out of order.
+
+QUESTION: Since this is a new specification should there be a requirement that IXoT servers are RECOMMENDED to condense responses as described in Section 6 of [RFC1995]. [RFC1995] document says this is optional and MAY be done but it can significantly reduce the size of responses and may have implications for padding?
 
 ### Fallback to AXFR
 
@@ -448,9 +450,10 @@ This is also possible with XoT but it must be noted that as with TCP the
 implementation of such an ACL cannot be enforced on the primary until a XFR
 request is received on an established connection.
 
-If control were to be any more fine-grained than this then a separate port would
-be required for XoT such that implementations would be able to refuse
-connections on that port to all clients except those configured as secondaries.
+If control were to be any more fine-grained than this then a separate, dedicated
+port would need to be agreed between primary and secondary for XoT such that
+implementations would be able to refuse connections on that port to all clients
+except those configured as secondaries.
 
 ## ZONEMD
 

--- a/draft-ietf-dprive-xfr-over-tls.xml
+++ b/draft-ietf-dprive-xfr-over-tls.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE rfc SYSTEM 'rfc2629.dtd' []>
-<rfc ipr="trust200902" category="std" docName="draft-ietf-dprive-xfr-over-tls-00" updates="1995">
+<rfc ipr="trust200902" category="std" docName="draft-ietf-dprive-xfr-over-tls-01" updates="1995">
 <?rfc toc="yes"?>
 <?rfc symrefs="yes"?>
 <?rfc sortrefs="yes"?>
@@ -90,7 +90,7 @@
 <uri></uri>
 </address>
 </author>
-<date year="2019" month="November" day="18"/>
+<date year="2020" month="May" day="19"/>
 
 <area>Internet</area>
 <workgroup>dprive</workgroup>
@@ -179,8 +179,6 @@ for two servers engaged in zone transfers.
 </t>
 <t>DoT: DNS-over-TLS as specified in <xref target="RFC7858"/>
 </t>
-<t>DoH: DNS-over-HTTPS as specified in <xref target="RFC8484"/>
-</t>
 <t>XoT: Generic XFR-over-TLS mechanisms as specified in this document
 </t>
 <t>AXoT: AXFR-over-TLS
@@ -200,10 +198,10 @@ with ACLs) can complement and potentially be an alternative to TSIG.</t>
 compatibility with older implementations based on the original specifications
 in <xref target="RFC1034"/> and <xref target="RFC1035"/>. For example, some older AXFR servers don’t
 support using a TCP connection for multiple AXFR sessions or XFRs of different
-zones because they have not been updated to follow the guidance in [RFC5836].
+zones because they have not been updated to follow the guidance in <xref target="RFC5936"/>.
 Any implementation of XFR-over-TLS would obviously be required to implement
 optimized and interoperable transfers as described in <xref target="RFC5936"/> e.g. transfer
-of multiple zones-over-one connection.</t>
+of multiple zones over one connection.</t>
 <t>Performance. Current usage of TCP for IXFR is sub-optimal in some cases i.e.
 connections are frequently closed after a single IXFR.</t>
 </list>
@@ -327,7 +325,7 @@ manage persistent connections.
 messages in the XFR mechanism.
 </t>
 <t>Since the SOA of the published zone can be trivially discovered by simply
-querying the publicly available authoritative servers leakage RR of this is not
+querying the publicly available authoritative servers leakage of this RR is not
 discussed in the following sections.
 </t>
 
@@ -362,12 +360,18 @@ applicable to XFR-over-TLS as well.
 <t>It is RECOMMENDED that clients and servers that support XoT also implement
 EDNS0 Keepalive [RFC7828].
 </t>
+<t>It is useful to note that in these mechanisms is it the secondary that initiates the TLS connection to the primary for a XFR request, so that in terms of connectivity the secondary is the TLS client and the primary the TLS server.
+</t>
 </section>
 
 <section anchor="axot-mechanism" title="AXoT mechanism">
 <t>The figure below provides an outline of the AXoT mechanism including NOTIFYs.
 </t>
 <t><eref target="https://github.com/hanzhang0116/hzpa-dprive-xfr-over-tls/blob/02_updates/02-draft-svg/AXoT_mechanism_1.svg">Figure 3: AXoT mechanism</eref>
+</t>
+<t>The connection for AXFR-over-TLS SHOULD be established using port 853, as
+specified in <xref target="RFC7858"/>, unless there is mutual agreement between the secondary
+and primary to use a port other than port 853 for XFR-over-TLS.
 </t>
 <t>All implementations that support XoT MUST fully implement <xref target="RFC5953"/> behavior
 on TLS connections.
@@ -384,10 +388,6 @@ use an open connection.)
 <t>For clarity we additionally state here that an AXoT client MAY use an already
 opened TLS connection to send a SOA request. Using an existing open connection
 is RECOMMENDED over opening a new connection.
-</t>
-<t>The connection for AXFR-over-TLS SHOULD be established using port 853, as
-specified in <xref target="RFC7858"/>, unless there is mutual agreement between the secondary
-and primary to use a port other than port 853 for XFR-over-TLS.
 </t>
 <t>QUESTION: Should there be a requirement that the SOA is always done on a TLS
 connection if the XFR is? For the case when no transfer is required this could
@@ -429,6 +429,8 @@ recommends that servers use timeouts of at least a few seconds).
 </t>
 <t>An IXoT client MAY pipeline IXFR requests for different zones on a single TLS
 connection. AN IXoT server MAY respond to those requests out of order.
+</t>
+<t>QUESTION: Since this is a new specification should there be a requirement that IXoT servers are RECOMMENDED to condense responses as described in Section 6 of [RFC1995]. [RFC1995] document says this is optional and MAY be done but it can significantly reduce the size of responses and may have implications for padding?
 </t>
 
 <section anchor="fallback-to-axfr" title="Fallback to AXFR">
@@ -494,12 +496,13 @@ Control List (ACL), which is often used in combination with TSIG based ACLs to
 restrict access to zone transfers on primary servers.
 </t>
 <t>This is also possible with XoT but it must be noted that as with TCP the
-implementation of such and ACL cannot be enforced on the primary until a XFR
+implementation of such an ACL cannot be enforced on the primary until a XFR
 request is received on an established connection.
 </t>
-<t>If control were to be any more fine-grained than this then a separate port would
-be required for XoT such that implementations would be able to refuse
-connections on that port to all clients except those configured as secondaries.
+<t>If control were to be any more fine-grained than this then a separate, dedicated
+port would need to be agreed between primary and secondary for XoT such that
+implementations would be able to refuse connections on that port to all clients
+except those configured as secondaries.
 </t>
 </section>
 


### PR DESCRIPTION
- remove DoH from terminology because it is not used later in the document
- be clearer that the secondary is the IXoT client
- move text on port choose up in section 5.2 to better match 5.3
- add question a condensation of responses
- clarify port requirement for ACL control